### PR TITLE
Add box privacy and box retrieval

### DIFF
--- a/api/controllers/BoxController.js
+++ b/api/controllers/BoxController.js
@@ -7,13 +7,14 @@
 
 module.exports = {
 
-  add: async function (req, res) {
+  add: function (req, res) {
     const params = req.allParams();
 
     Box.create({
       name: params.name,
-      user: req.user.username,
-      description: params.description
+      user: req.user.name,
+      description: params.description,
+      id: require('crypto').randomBytes(16).toString('hex')
     }, function (err, box) {
       if (err) {
         return res.badRequest();
@@ -21,6 +22,5 @@ module.exports = {
         return res.ok(box);
       }
     })
-  },
-
+  }
 };

--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -1,23 +1,46 @@
 const pk6parse = require('pk6parse');
+const moment = require('moment');
 exports.uploadpk6 = async (req, res) => {
   try {
     const params = req.allParams();
-    const parsed = await new Promise((resolve, reject) => {
-      req.file('pk6').upload((err, files) => (
-        err ? reject(err) : resolve(pk6parse.parseFile(files[0].fd))
-      ));
-    });
     const visibility = params.visibility;
     if (visibility && !_.includes(['private', 'public', 'readonly'], visibility)) {
-      return res.badRequest();
+      return res.status(400).json('Invalid visibility setting');
     }
+    const files = await new Promise((resolve, reject) => {
+      req.file('pk6').upload((err, files) => err ? reject(err) : resolve(files));
+    });
+    if (!files.length) {
+      return res.status(400).json('No files uploaded');
+    }
+    const parsed = _.attempt(pk6parse.parseFile, files[0].fd);
+    if (_.isError(parsed)) {
+      return res.status(400).json('Failed to parse the provided file');
+    }
+    let box;
+    if (params.box) {
+      box = await Box.findOne({id: params.box});
+      if (!box) {
+        return res.status(400).json(`Box ${params.box} not found`);
+      }
+      if (box.owner !== req.user.name) {
+        return res.status(403).json("Cannot upload to another user's box");
+      }
+    } else {
+      box = await Box.create({
+        name: `Untitled Box ${moment.utc().format('YYYY-MM-DD HH:mm:ss')}`,
+        owner: req.user.name,
+        id: require('crypto').randomBytes(16).toString('hex')
+      });
+    }
+    parsed.box = box.id;
     parsed.owner = req.user.name;
     parsed.visibility = visibility;
     parsed.cloneHash = PokemonHandler.computeCloneHash(parsed);
     parsed.id = require('crypto').randomBytes(16).toString('hex');
     const result = await Pokemon.create(parsed);
     result.isUnique = await result.checkIfUnique();
-    return res.send(201, result);
+    return res.status(201).json(result);
   } catch (err) {
     return res.serverError(err);
   }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1,0 +1,19 @@
+module.exports = {
+  async boxes (req, res) {
+    try {
+      const user = await User.findOne({id: req.param('name')}).populate('boxes');
+      if (!user) {
+        return res.notFound();
+      }
+      const boxes = user.boxes;
+      if (req.user.name === user.name) {
+        return res.ok(boxes);
+      }
+      return res.ok(
+        _.reject(boxes, b => b.visibility === 'unlisted').map(b => b.omitPrivateContents())
+      );
+    } catch (err) {
+      return res.serverError(err);
+    }
+  }
+};

--- a/api/models/Box.js
+++ b/api/models/Box.js
@@ -6,12 +6,32 @@ module.exports =  {
     name: {
       type: 'string'
     },
-    user: {
-      model: 'User',
+    owner: {
+      model: 'user',
       required: true
     },
     description: {
-      type: 'string'
+      type: 'string',
+      defaultsTo: ''
+    },
+    visibility: {
+      enum: ['listed', 'unlisted'],
+      defaultsTo: 'listed'
+    },
+    contents: {
+      collection: 'pokemon',
+      via: 'box',
+      defaultsTo: []
+    },
+    id: {
+      type: 'string',
+      unique: true,
+      primaryKey: true
+    },
+    omitPrivateContents () {
+      return _.assign(_.clone(this), {contents: _(this.contents).map(pokemon => {
+        return pokemon.visibility === 'public' ? pokemon : pokemon.omitPrivateData();
+      }).reject(pokemon => pokemon.visibility === 'private').value()});
     }
   }
 };

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -3,7 +3,7 @@ module.exports =  {
   schema: true,
 
   attributes: {
-    username: {
+    name: {
       type: 'string',
       columnName: 'id',
       unique: true,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -18,8 +18,8 @@ module.exports =  {
       via: 'user'
     },
     boxes: {
-      collection: 'Box',
-      via: 'user'
+      collection: 'box',
+      via: 'owner'
     }
   }
 };

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -83,14 +83,14 @@ passport.connect = function (req, query, profile, next) {
     user.email = profile.emails[0].value;
   }
   // If the profile object contains a username, add it to the user.
-  if (profile.hasOwnProperty('username')) {
-    user.username = profile.username;
+  if (profile.hasOwnProperty('name')) {
+    user.name = profile.name;
   }
 
   // If neither an email or a username was available in the profile, we don't
   // have a way of identifying the user in the future. Throw an error and let
   // whoever's next in the line take care of it.
-  if (!user.username && !user.email) {
+  if (!user.name && !user.email) {
     return next(new Error('Neither a username nor email was available'));
   }
 
@@ -120,7 +120,7 @@ passport.connect = function (req, query, profile, next) {
             return next(err);
           }
 
-          query.user = user.username;
+          query.user = user.name;
 
           Passport.create(query, function (err, passport) {
             // If a passport wasn't created, bail out
@@ -147,7 +147,7 @@ passport.connect = function (req, query, profile, next) {
           }
 
           // Fetch the user associated with the Passport
-          User.findOne(passport.user.username, next);
+          User.findOne(passport.user.name, next);
         });
       }
     } else {
@@ -155,7 +155,7 @@ passport.connect = function (req, query, profile, next) {
       //           passport.
       // Action:   Create and assign a new passport to the user.
       if (!passport) {
-        query.user = req.user.username;
+        query.user = req.user.name;
 
         Passport.create(query, function (err, passport) {
           // If a passport wasn't created, bail out
@@ -341,7 +341,7 @@ passport.disconnect = function (req, res, next) {
     provider = req.param('provider', 'local'),
     query    = {};
 
-  query.user = user.username;
+  query.user = user.name;
   query[provider === 'local' ? 'protocol' : 'provider'] = provider;
 
   Passport.findOne(query, function (err, passport) {
@@ -360,7 +360,7 @@ passport.disconnect = function (req, res, next) {
 };
 
 passport.serializeUser(function (user, next) {
-  next(null, user.username);
+  next(null, user.name);
 });
 
 passport.deserializeUser(function (id, next) {

--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -25,7 +25,7 @@ const crypto    = require('crypto');
  */
 exports.register = function (req, res, next) {
   const email    = req.param('email'),
-    username = req.param('username'),
+    name = req.param('name'),
     password = req.param('password');
 
   if (!email) {
@@ -33,7 +33,7 @@ exports.register = function (req, res, next) {
     return next(new Error('No email was entered.'));
   }
 
-  if (!username) {
+  if (!name) {
     req.flash('error', 'Error.Passport.Username.Missing');
     return next(new Error('No username was entered.'));
   }
@@ -44,7 +44,7 @@ exports.register = function (req, res, next) {
   }
 
   User.create({
-    username: username,
+    name: name,
     email: email
   }, function (err, user) {
     if (err) {
@@ -66,7 +66,7 @@ exports.register = function (req, res, next) {
     Passport.create({
       protocol: 'local',
       password: password,
-      user: user.username,
+      user: user.name,
       accessToken: token
     }, function (err, passport) {
       if (err) {
@@ -101,7 +101,7 @@ exports.connect = function (req, res, next) {
 
   Passport.findOne({
     protocol: 'local',
-    user: user.username
+    user: user.name
   }, function (err, passport) {
     if (err) {
       return next(err);
@@ -111,7 +111,7 @@ exports.connect = function (req, res, next) {
       Passport.create({
         protocol: 'local',
         password: password,
-        user: user.username
+        user: user.name
       }, function (err, passport) {
         next(err, user);
       });
@@ -140,7 +140,7 @@ exports.login = function (req, identifier, password, next) {
   if (isEmail) {
     query.email = identifier;
   } else {
-    query.username = identifier;
+    query.name = identifier;
   }
 
   User.findOne(query, function (err, user) {
@@ -160,7 +160,7 @@ exports.login = function (req, identifier, password, next) {
 
     Passport.findOne({
       protocol: 'local',
-      user: user.username
+      user: user.name
     }, function (err, passport) {
       if (passport) {
         passport.validatePassword(password, function (err, res) {

--- a/client/header.ejs
+++ b/client/header.ejs
@@ -9,7 +9,7 @@
 
     <% if (typeof user !== 'undefined') {%>
       <add-menu boxes="main.boxes"></add-menu>
-      <user-menu name="'<%= user.username %>'"></user-menu>
+      <user-menu name="'<%= user.name %>'"></user-menu>
     <% } else { %>
       <a class="mdl-navigation__link" href="/login">Login/Register</a>
     <% } %>

--- a/config/routes.js
+++ b/config/routes.js
@@ -27,6 +27,8 @@ module.exports.routes = {
   // Boxes
 
   'post /box': 'BoxController.add',
+  'get /b/:id': 'BoxController.get',
+  'get /boxes/mine': 'BoxController.mine',
 
   // Authentication
 
@@ -48,5 +50,9 @@ module.exports.routes = {
 
   'get /p/:id': 'PokemonController.get',
   'delete /p/:id': 'PokemonController.delete',
-  'get /pokemon/mine': 'PokemonController.mine'
+  'get /pokemon/mine': 'PokemonController.mine',
+
+  // Users
+  'get /user/:name/boxes': 'UserController.boxes'
+
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt": "0.4.5",
     "include-all": "0.1.6",
     "less": "^2.6.0",
+    "moment": "^2.11.2",
     "passport": "^0.3.2",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "concurrently": "^1.0.0",
     "connect-mongo": "^0.8.2",
     "ejs": "2.3.4",
-    "eslint": "^2.0.0",
+    "eslint": "=2.2.0",
     "grunt": "0.4.5",
     "include-all": "0.1.6",
     "less": "^2.6.0",

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -20,7 +20,7 @@ describe('AuthController', function() {
 
     it('should be able to register an account', async () => {
       const res = await agent.post('/auth/local/register').send({
-        username: 'testuser1',
+        name: 'testuser1',
         password: 'hunter22',
         email: 'testuser1@gmail.com'
       });
@@ -32,9 +32,9 @@ describe('AuthController', function() {
       expect((await agent.get('/')).statusCode).to.equal(200);
     });
 
-    it("shouldn't register an account with an already-existing username", async () => {
+    it("shouldn't register an account with an already-existing name", async () => {
       const res = await otherAgent.post('/auth/local/register').send({
-        username: 'testuser1',
+        name: 'testuser1',
         password: 'beepboop',
         email: 'testuser1spoof@gmail.com'
       });
@@ -44,7 +44,7 @@ describe('AuthController', function() {
 
     it("shouldn't register an account with an already-existing email", async () => {
       const res = await otherAgent.post('/auth/local/register').send({
-        username: 'testuser2',
+        name: 'testuser2',
         password: 'beepboop',
         email: 'testuser1@gmail.com'
       });
@@ -54,7 +54,7 @@ describe('AuthController', function() {
 
     it("shouldn't register an account with a password less than 8 characters", async () => {
       const res = await otherAgent.post('/auth/local/register').send({
-        username: 'testuser2',
+        name: 'testuser2',
         password: 'one',
         email: 'testuser2@gmail.com'
       });
@@ -64,7 +64,7 @@ describe('AuthController', function() {
 
     it('should not allow logins with invalid passwords', async () => {
       const res = await otherAgent.post('/auth/local/login').send({
-        username: 'testuser1',
+        name: 'testuser1',
         password: 'not_the_correct_password'
       });
       expect(res.statusCode).to.equal(302);
@@ -73,7 +73,7 @@ describe('AuthController', function() {
 
     it('should not allow logins with invalid user but the password of another', async () => {
       const res = await otherAgent.post('/auth/local/login').send({
-        username: 'testuser2',
+        name: 'testuser2',
         password: 'hunter22'
       });
       expect(res.statusCode).to.equal(302);

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -1,0 +1,78 @@
+const supertest = require('supertest-as-promised');
+const expect = require('chai').expect;
+const _ = require('lodash');
+describe('box handling', () => {
+  let agent, otherAgent;
+  before(async () => {
+    agent = supertest.agent(sails.hooks.http.app);
+    otherAgent = supertest.agent(sails.hooks.http.app);
+    const res = await agent.post('/auth/local/register').send({
+      name: 'boxtester',
+      password: '********',
+      email: 'boxtester@boxtesting.com'
+    });
+    expect(res.statusCode).to.equal(302);
+    expect(res.header.location).to.equal('/');
+
+    const res2 = await otherAgent.post('/auth/local/register').send({
+      name: 'EXPLOUD_BOX',
+      password: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      email: 'AAAAAAAA@BOXBOXBOXBOXBOX.com'
+    });
+    expect(res2.statusCode).to.equal(302);
+    expect(res.header.location).to.equal('/');
+  });
+  describe('creating a box', () => {
+    it('can create a box', async () => {
+      const res = await agent.post('/box').send({name: 'Pizza Box', description: 'A box'});
+      expect(res.body.owner).to.equal('boxtester');
+      expect(res.body.name).to.equal('Pizza Box');
+      expect(res.body.description).to.equal('A box');
+    });
+  });
+  describe('getting a box', () => {
+    let box1Id;
+    before(async () => {
+      box1Id = (await agent.post('/box').send({name: 'Jukebox'})).body.id;
+      await agent.post('/box').send({name: 'Sandbox'});
+      await agent.post('/box').send({name: 'Penalty Box', visibility: 'unlisted'});
+      await otherAgent.post('/box').send({name: "Pandora's Box"});
+      await Promise.each(['readonly', 'public', 'private'], visibility => {
+        return agent.post('/uploadpk6')
+          .attach('pk6', __dirname + '/pkmn1.pk6')
+          .field('box', box1Id)
+          .field('visibility', visibility);
+      });
+    })
+    it('allows a user to view the contents of their box by ID', async () => {
+      const box1 = (await agent.get(`/b/${box1Id}`)).body;
+      expect(box1.id).to.equal(box1Id);
+      expect(box1.contents).to.have.lengthOf(3);
+      expect(box1.contents[0].pid).to.exist;
+      expect(box1.contents[1].pid).to.exist;
+      expect(box1.contents[2].pid).to.exist;
+    });
+    it('allows third parties to view a box, filtering contents by pokemon visibility', async () => {
+      const box1 = (await otherAgent.get(`/b/${box1Id}`)).body;
+      expect(box1.id).to.equal(box1Id);
+      expect(box1.contents[0].visibility).to.equal('readonly');
+      expect(box1.contents[0].pid).to.not.exist;
+      expect(box1.contents[1].visibility).to.equal('public');
+      expect(box1.contents[1].pid).to.exist;
+      expect(box1.contents[2]).to.not.exist;
+    });
+    it('allows a user to get their own boxes', async () => {
+      const boxNames = _.map((await agent.get('/boxes/mine')).body, 'name');
+      expect(boxNames).to.include('Jukebox');
+      expect(boxNames).to.include('Sandbox');
+      expect(boxNames).to.include('Penalty Box');
+      expect(boxNames).to.not.include("Pandora's Box");
+    });
+    it("allows a third party to get a user's listed boxes", async () => {
+      const listedBoxNames = _.map((await otherAgent.get('/user/boxtester/boxes')).body, 'name');
+      expect(listedBoxNames).to.include('Jukebox');
+      expect(listedBoxNames).to.include('Sandbox');
+      expect(listedBoxNames).to.not.include('Penalty Box');
+    });
+  });
+});

--- a/test/controller/not_a_pk6_file.txt
+++ b/test/controller/not_a_pk6_file.txt
@@ -1,0 +1,1 @@
+This is not a .pk6 file.

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -37,6 +37,10 @@ describe('pokemon handling', () => {
       expect(res2.statusCode).to.equal(201);
       expect(res2.body.isUnique).to.be.false;
     });
+    it("should reject uploads that aren't pk6 files", async () => {
+      const res = await agent.post('/uploadpk6').attach('pk6', `${__dirname}/not_a_pk6_file.txt`);
+      expect(res.statusCode).to.equal(400);
+    });
   });
   describe('getting a pokemon by ID', () => {
     let publicId, privateId, readOnlyId;

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -7,7 +7,7 @@ describe('pokemon handling', () => {
     agent = supertest.agent(sails.hooks.http.app);
     otherAgent = supertest.agent(sails.hooks.http.app);
     const res = await agent.post('/auth/local/register').send({
-      username: 'pk6tester',
+      name: 'pk6tester',
       password: '********',
       email: 'pk6tester@pk6testing.com'
     });
@@ -15,7 +15,7 @@ describe('pokemon handling', () => {
     expect(res.header.location).to.equal('/');
 
     const res2 = await otherAgent.post('/auth/local/register').send({
-      username: 'EXPLOUD_BOT',
+      name: 'EXPLOUD_BOT',
       password: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       email: 'AAAAAAAA@AAAAAAAA.com'
     });


### PR DESCRIPTION
This PR includes the changes from #63, so take a look at those first.

New endpoints:

* `GET /b/:id`: Gets a box by ID. This takes Pokémon privacy into account. If the current user is not the box's owner, private Pokémon in the box will not appear, and readonly Pokémon will have their private information omitted.
* `GET /boxes/mine`: Gets all of the current user's boxes
* `GET /user/:name/boxes`: Gets all of the boxes for a given user. When getting someone else's boxes, boxes marked as "unlisted" are excluded from the response.
* A few changes to `POST /uploadpk6`: It now accepts a `box` form field representing the ID of a box where the newly-uploaded Pokémon should be put. If this field is omitted, a new timestamped box is created to hold the uploaded Pokémon.

Fixes #14. Handles the serverside portion of #21. Addresses #17, but does not support changing the settings yet after the box is created.