### PR TITLE
Add editing endpoints

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -10,6 +10,7 @@
     'Constants': true,
     'UserPreferences': true,
     'PokemonNote': true,
-    'CatchAsyncErrors': true
+    'CatchAsyncErrors': true,
+    'Validation': true
   }
 }

--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -11,6 +11,7 @@
     'UserPreferences': true,
     'PokemonNote': true,
     'CatchAsyncErrors': true,
-    'Validation': true
+    'Validation': true,
+    'DeletedUser': true
   }
 }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -62,5 +62,22 @@ module.exports = _.mapValues({
     user.isAdmin = false;
     await user.save();
     return res.ok();
+  },
+  async deleteAccount (req, res) {
+    const params = req.allParams();
+    Validation.requireParams(params, 'password');
+    const userPassport = await Passport.findOne({user: req.user.name, protocol: 'local'});
+    const validate = userPassport.validatePassword.bind(userPassport);
+    const isValid = await Promise.promisify(validate)(params.password);
+    if (!isValid) {
+      return res.forbidden('Incorrect password');
+    }
+    await req.user.deleteAccount();
+    return res.redirect('/');
+  },
+  async checkUsernameAvailable (req, res) {
+    const params = req.allParams();
+    Validation.requireParams(params, 'name');
+    return res.ok(await Validation.usernameAvailable(params.name));
   }
 }, CatchAsyncErrors);

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1,9 +1,7 @@
 module.exports = _.mapValues({
   async get (req, res) {
     const params = req.allParams();
-    if (!params.name) {
-      return res.badRequest();
-    }
+    Validation.requireParams(params, 'name');
     const user = await User.findOne({name: params.name}).populate('preferences');
     if (!user) {
       return res.notFound();
@@ -37,10 +35,8 @@ module.exports = _.mapValues({
   },
   async editPreferences (req, res) {
     // Only allow users to change the preferences that have been explicitly marked as modifiable
-    const filteredParams = _.pick(req.allParams(), _.keys(Constants.CHANGEABLE_PREFERENCES));
-    if (_.isEmpty(filteredParams)) {
-      return res.badRequest('No valid preferences specified');
-    }
+    const params = req.allParams();
+    const filteredParams = Validation.filterParams(params, Constants.CHANGEABLE_PREFERENCES);
     for (const i of _.keys(filteredParams)) {
       if (!Constants.CHANGEABLE_PREFERENCES[i].enum.includes(filteredParams[i])) {
         return res.badRequest(`Invalid value for preference '${i}'`);

--- a/api/models/Box.js
+++ b/api/models/Box.js
@@ -4,7 +4,8 @@ module.exports =  {
 
   attributes: {
     name: {
-      type: 'string'
+      type: 'string',
+      required: true
     },
     owner: {
       model: 'user',

--- a/api/models/DeletedUser.js
+++ b/api/models/DeletedUser.js
@@ -1,0 +1,11 @@
+module.exports = {
+  schema: true,
+  attributes: {
+    name: {
+      required: true,
+      type: 'string',
+      unique: true,
+      primaryKey: true
+    }
+  }
+};

--- a/api/models/Passport.js
+++ b/api/models/Passport.js
@@ -50,7 +50,8 @@ const Passport = {
     // passport (with protocol 'local') is created for a user.
     password: {
       type: 'string',
-      minLength: 8
+      minLength: 8,
+      maxLength: 72
     },
     accessToken: {
       type: 'string'

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -38,6 +38,15 @@ module.exports =  {
     },
     omitPrivateInformation () {
       return _.omit(this, ['passports', 'email', 'preferences', 'updatedAt']);
+    },
+    async deleteAccount () {
+      await Promise.all([
+        UserPreferences.destroy({user: this.name}),
+        Promise.map(Box.find({owner: this.name}), box => box.destroy()),
+        Passport.destroy({user: this.name})
+      ]);
+      await User.destroy({name: this.name});
+      await DeletedUser.create({name: this.name});
     }
   }
 };

--- a/api/services/Constants.js
+++ b/api/services/Constants.js
@@ -27,3 +27,5 @@ exports.CHANGEABLE_PREFERENCES = {
 // The number of milliseconds for which deleted boxes/pokemon should be cached before they are permanently deleted.
 exports.BOX_DELETION_DELAY = 300000; // (i.e. 5 minutes)
 exports.POKEMON_DELETION_DELAY = 300000;
+
+exports.VALID_USERNAME_REGEX = /^[a-zA-Z0-9_-]{1,20}$/;

--- a/api/services/Validation.js
+++ b/api/services/Validation.js
@@ -64,5 +64,13 @@ module.exports = {
     if (!Constants.POKEMON_NOTE_VISIBILITIES.includes(note.visibility)) {
       throw {statusCode: 400, message: 'Invalid note visibility'};
     }
+  },
+  async usernameAvailable (name) {
+    if (!_.isString(name) || !Constants.VALID_USERNAME_REGEX.test(name)) {
+      return false;
+    }
+    const existingUser = await User.findOne({name});
+    const deletedUser = await DeletedUser.findOne({name});
+    return !(existingUser || deletedUser);
   }
 };

--- a/api/services/Validation.js
+++ b/api/services/Validation.js
@@ -40,5 +40,29 @@ module.exports = {
   },
   verifyUserIsBoxOwner (...args) {
     return module.exports.verifyUserIsOwner(Box, ...args);
+  },
+  verifyBoxParams (box) {
+    if (!_.isString(box.name) || _.isEmpty(box.name)) {
+      throw {statusCode: 400, message: 'Invalid box name'};
+    }
+    if (box.description && !_.isString(box.description)) {
+      throw {statusCode: 400, message: 'Invalid box description'};
+    }
+    if (!Constants.BOX_VISIBILITIES.includes(box.visibility)) {
+      throw {statusCode: 400, message: 'Invalid box visibility'};
+    }
+  },
+  verifyPokemonParams (pokemon) {
+    if (!Constants.POKEMON_VISIBILITIES.includes(pokemon.visibility)) {
+      throw {statusCode: 400, message: 'Invalid pokemon visibility'};
+    }
+  },
+  verifyPokemonNoteParams (note) {
+    if (!_.isString(note.text) || _.isEmpty(note.text)) {
+      throw {statusCode: 400, message: 'Invalid note text'};
+    }
+    if (!Constants.POKEMON_NOTE_VISIBILITIES.includes(note.visibility)) {
+      throw {statusCode: 400, message: 'Invalid note visibility'};
+    }
   }
 };

--- a/api/services/Validation.js
+++ b/api/services/Validation.js
@@ -1,0 +1,16 @@
+module.exports = {
+  filterParams (allParams, legalParams, {throwOnEmpty = true} = {}) {
+    const filtered = _.pick(allParams, _.isArray(legalParams) ? legalParams : _.keys(legalParams));
+    if (_.isEmpty(filtered) && throwOnEmpty) {
+      throw {statusCode: 400, message: 'No valid parameters specified'};
+    }
+    return filtered;
+  },
+  requireParams (allParams, requiredValues) {
+    _.forEach(_.isArray(requiredValues) ? requiredValues : [requiredValues], param => {
+      if (!_.has(allParams, param)) {
+        throw {statusCode: 400, message: `Missing parameter ${param}`};
+      }
+    });
+  }
+};

--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -42,6 +42,15 @@ exports.register = async function (req, res, next) {
     req.flash('error', 'Error.Passport.Password.Missing');
     return next(new Error('No password was entered.'));
   }
+  try {
+    const nameAvailable = await Validation.usernameAvailable(name);
+    if (!nameAvailable) {
+      req.flash('error', 'Error.Passport.Bad.Username');
+      return next(new Error('That username is unavailable.'));
+    }
+  } catch (err) {
+    return next(err);
+  }
   let user, token;
   try {
     user = await User.create({name, email});

--- a/config/policies.js
+++ b/config/policies.js
@@ -66,7 +66,9 @@ module.exports.policies = {
     boxes: anyone,
     me: user,
     getPreferences: user,
-    editPreferences: user
+    editPreferences: user,
+    deleteAccount: user,
+    checkUsernameAvailable: anyone
   }
 
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -57,7 +57,8 @@ module.exports.policies = {
     get: anyone,
     mine: user,
     delete: user,
-    undelete: user
+    undelete: user,
+    edit: user
   },
 
   UserController: {

--- a/config/policies.js
+++ b/config/policies.js
@@ -48,7 +48,8 @@ module.exports.policies = {
     move: user,
     addNote: user,
     deleteNote: user,
-    editNote: user
+    editNote: user,
+    edit: user
   },
 
   BoxController: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -69,5 +69,7 @@ module.exports.routes = {
   'get /preferences': 'UserController.getPreferences',
   'post /preferences/edit': 'UserController.editPreferences',
   'post /user/:name/grantAdminStatus': 'UserController.grantAdminStatus',
-  'post /user/:name/revokeAdminStatus': 'UserController.revokeAdminStatus'
+  'post /user/:name/revokeAdminStatus': 'UserController.revokeAdminStatus',
+  'post /deleteAccount': 'UserController.deleteAccount',
+  'get /checkUsernameAvailable': 'UserController.checkUsernameAvailable'
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -31,6 +31,7 @@ module.exports.routes = {
   'get /boxes/mine': 'BoxController.mine',
   'delete /b/:id': 'BoxController.delete',
   'post /b/:id/undelete': 'BoxController.undelete',
+  'post /b/:id/edit': 'BoxController.edit',
 
   // Authentication
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -59,6 +59,7 @@ module.exports.routes = {
   'post /p/:id/note': 'PokemonController.addNote',
   'delete /p/:id/n/:noteId': 'PokemonController.deleteNote',
   'post /p/:id/n/:noteId/edit': 'PokemonController.editNote',
+  'post /p/:id/edit': 'PokemonController.edit',
 
   // Users
   'get /user/:name': 'UserController.get',

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -5,9 +5,14 @@ require('babel-polyfill');
 describe('AuthController', function() {
   let agent;
   let otherAgent;
+  let invalidAgent;
   before(() => {
     agent = supertest.agent(sails.hooks.http.app);
+  });
+
+  beforeEach(() => {
     otherAgent = supertest.agent(sails.hooks.http.app);
+    invalidAgent = supertest.agent(sails.hooks.http.app);
   });
 
   describe('#login()', function(done) {
@@ -63,21 +68,89 @@ describe('AuthController', function() {
     });
 
     it('should not allow logins with invalid passwords', async () => {
-      const res = await otherAgent.post('/auth/local/login').send({
-        name: 'testuser1',
+      const res = await otherAgent.post('/auth/local').send({
+        identifier: 'testuser1',
         password: 'not_the_correct_password'
       });
       expect(res.statusCode).to.equal(302);
       expect(res.header.location).to.equal('/login');
     });
 
+    it('does not allow a login with very similar passwords up to 72 characters', async () => {
+      const res = await otherAgent.post('/auth/local/register').send({
+        name: 'validUsername',
+        // 72 asterisks
+        password: '************************************************************************',
+        email: 'invalid5@porybox.com'
+      });
+      expect(res.statusCode).to.equal(302);
+      expect(res.header.location).to.equal('/');
+      const res2 = await invalidAgent.post('/auth/local').send({
+        identifier: 'validUsername',
+        // 71 asterisks followed by an 'a'
+        password: '***********************************************************************a'
+      });
+      expect(res2.statusCode).to.equal(302);
+      expect(res2.header.location).to.equal('/login');
+    });
+
+    it('should allow logins with valid passwords', async () => {
+      const res = await otherAgent.post('/auth/local').send({
+        identifier: 'testuser1',
+        password: 'hunter22'
+      });
+      expect(res.statusCode).to.equal(302);
+      expect(res.header.location).to.equal('/');
+    });
+
     it('should not allow logins with invalid user but the password of another', async () => {
       const res = await otherAgent.post('/auth/local/login').send({
-        name: 'testuser2',
+        identifier: 'testuser2',
         password: 'hunter22'
       });
       expect(res.statusCode).to.equal(302);
       expect(res.header.location).to.equal('/login');
+    });
+
+    it('should not allow registration with usernames that contain special characters', async () => {
+      const res = await invalidAgent.post('/auth/local/register').send({
+        name: 'testuseréééé',
+        password: 'blahblahblah',
+        email: 'invalid@porybox.com'
+      });
+      expect(res.statusCode).to.equal(302);
+      expect(res.header.location).to.equal('/register');
+    });
+
+    it('should not allow registration with a username that has been deleted', async () => {
+      const res = await otherAgent.post('/auth/local/register').send({
+        name: 'claimedUsername2',
+        password: 'blahblahblah',
+        email: 'invalid3@porybox.com'
+      });
+      expect(res.statusCode).to.equal(302);
+      expect(res.header.location).to.equal('/');
+      const res2 = await otherAgent.post('/deleteAccount').send({password: 'blahblahblah'});
+      expect(res2.statusCode).to.equal(302);
+      expect(res2.header.location).to.equal('/');
+      const res3 = await invalidAgent.post('/auth/local/register').send({
+        name: 'CLAIMEDUSERNAME2',
+        password: 'AAAAAAAAAAAAA',
+        email: 'invalid4@porybox.com'
+      });
+      expect(res3.statusCode).to.equal(302);
+      expect(res3.header.location).to.equal('/register');
+    });
+
+    it('does not allow passwords longer than 72 characters', async () => {
+      const res = await otherAgent.post('/auth/local/register').send({
+        name: 'UNIQUE_USERNAME',
+        // 73 asterisks
+        password: '*************************************************************************',
+        email: 'invalid5@porybox.com'
+      });
+      expect(res.statusCode).to.equal(302);
+      expect(res.header.location).to.equal('/register');
     });
   });
 });

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -350,5 +350,9 @@ describe('BoxController', () => {
       const res2 = await agent.post(`/b/${box.id}/edit`).send({description: 'a box'});
       expect(res2.statusCode).to.equal(404);
     });
+    it("does not allow a box's name to be edited to the empty string", async () => {
+      const res = await agent.post(`/b/${box.id}/edit`).send({name: ''});
+      expect(res.statusCode).to.equal(400);
+    });
   });
 });

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -588,5 +588,11 @@ describe('PokemonController', () => {
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.visibility).to.equal('private');
     });
+    it('does not allow a deleted pokemon to be edited', async () => {
+      const res = await agent.del(`/p/${pkmn.id}`);
+      expect(res.statusCode).to.equal(202);
+      const res2 = await agent.post(`/p/${pkmn.id}/edit`).send({visibility: 'private'});
+      expect(res2.statusCode).to.equal(404);
+    });
   });
 });

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -553,4 +553,40 @@ describe('PokemonController', () => {
       expect(res2.statusCode).to.equal(404);
     });
   });
+  describe("editing a pokemon's visibility", () => {
+    let pkmn;
+    beforeEach(async () => {
+      const res = await agent.post('/uploadpk6')
+        .attach('pk6', `${__dirname}/pkmn1.pk6`)
+        .field('visibility', 'readonly');
+      expect(res.statusCode).to.equal(201);
+      pkmn = res.body;
+    });
+    it("allows a user to edit their pokemon's visibility", async () => {
+      const res = await agent.post(`/p/${pkmn.id}/edit`).send({visibility: 'private'});
+      expect(res.statusCode).to.equal(200);
+      const res2 = await agent.get(`/p/${pkmn.id}`);
+      expect(res2.statusCode).to.equal(200);
+      expect(res2.body.visibility).to.equal('private');
+    });
+    it('returns a 400 error if no valid parameters are specified', async () => {
+      const res = await agent.post(`/p/${pkmn.id}/edit`).send({owner: 'AAAAA'});
+      expect(res.statusCode).to.equal(400);
+    });
+    it('returns a 404 error if given an invalid pokemon id', async () => {
+      const res = await agent.post('/p/invalidpokemonid/edit').send({visibility: 'private'});
+      expect(res.statusCode).to.equal(404);
+    });
+    it("does not allow a user to edit another user's pokemon's visibility", async () => {
+      const res = await otherAgent.post(`/p/${pkmn.id}/edit`).send({visibility: 'private'});
+      expect(res.statusCode).to.equal(403);
+    });
+    it("allows an admin to edit a pokemon's visibility", async () => {
+      const res = await adminAgent.post(`/p/${pkmn.id}/edit`).send({visibility: 'private'});
+      expect(res.statusCode).to.equal(200);
+      const res2 = await agent.get(`/p/${pkmn.id}`);
+      expect(res2.statusCode).to.equal(200);
+      expect(res2.body.visibility).to.equal('private');
+    });
+  });
 });


### PR DESCRIPTION
`POST /p/:id/edit`: Edits the meta-properties of a pokemon. Currently `visibility` is the only property that this applies to, but it should be easily scalable if we add more properties. Accepts the properties that should be changed as parameters (e.g. `{visibility: 'private'}`)

`POST /b/:id/edit`: Edits the meta-properties of a box. Currently the properties are `name`, `description`, and `visibility`.

`POST /deleteAccount`: Deletes the authenticated user's account. Requires a `password` parameter, which must be the authenticated user's password.

Fixes #17, fixes #22, fixes #72