### PR TITLE
Add editable account info

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,6 +1,18 @@
+function matchesAll (testRegex, array) {
+  // Checks whether every element in `array` matches the given `testRegex`.
+  return array.every(value => _.isString(value) && testRegex.test(value));
+}
+
+
 module.exports =  {
   // Enforce model schema in the case of schemaless databases
   schema: true,
+
+  types: {
+    containsOnlyFriendCodes: _.partial(matchesAll, Constants.FRIEND_CODE_REGEX),
+    containsOnlyValidIGNs: _.partial(matchesAll, Constants.IGN_REGEX),
+    containsOnlyTSVs: _.partial(matchesAll, Constants.TSV_REGEX)
+  },
 
   attributes: {
     name: {
@@ -35,6 +47,21 @@ module.exports =  {
     isAdmin: {
       type: 'boolean',
       defaultsTo: false
+    },
+    friendCodes: {
+      type: 'array',
+      containsOnlyFriendCodes: true,
+      defaultsTo: []
+    },
+    inGameNames: {
+      type: 'array',
+      containsOnlyValidIGNs: true,
+      defaultsTo: []
+    },
+    trainerShinyValues: {
+      type: 'array',
+      containsOnlyTSVs: true,
+      defaultsTo: []
     },
     omitPrivateInformation () {
       return _.omit(this, ['passports', 'email', 'preferences', 'updatedAt']);

--- a/api/services/Constants.js
+++ b/api/services/Constants.js
@@ -29,3 +29,6 @@ exports.BOX_DELETION_DELAY = 300000; // (i.e. 5 minutes)
 exports.POKEMON_DELETION_DELAY = 300000;
 
 exports.VALID_USERNAME_REGEX = /^[a-zA-Z0-9_-]{1,20}$/;
+exports.FRIEND_CODE_REGEX = /^\d{4}-\d{4}-\d{4}$/;
+exports.IGN_REGEX = /^.{1,12}$/;
+exports.TSV_REGEX = /^([0-3]\d{3}|40([0-8]\d|9[0-5]))$/; // (matches any 4-digit string between 0000 and 4095, inclusive)

--- a/api/services/Validation.js
+++ b/api/services/Validation.js
@@ -47,6 +47,11 @@ module.exports = {
       throw {statusCode: 400, message: 'Invalid note visibility'};
     }
   },
+  assert (value, message) {
+    if (!value) {
+      throw {statusCode: 400, message};
+    }
+  },
   async usernameAvailable (name) {
     if (!_.isString(name) || !Constants.VALID_USERNAME_REGEX.test(name)) {
       return false;

--- a/config/policies.js
+++ b/config/policies.js
@@ -67,6 +67,7 @@ module.exports.policies = {
     me: user,
     getPreferences: user,
     editPreferences: user,
+    editAccountInfo: user,
     deleteAccount: user,
     changePassword: user,
     checkUsernameAvailable: anyone

--- a/config/routes.js
+++ b/config/routes.js
@@ -68,6 +68,7 @@ module.exports.routes = {
   'get /api/v1/me': 'UserController.me',
   'get /preferences': 'UserController.getPreferences',
   'post /preferences/edit': 'UserController.editPreferences',
+  'post /editAccountInfo': 'UserController.editAccountInfo',
   'post /user/:name/grantAdminStatus': 'UserController.grantAdminStatus',
   'post /user/:name/revokeAdminStatus': 'UserController.revokeAdminStatus',
   'post /deleteAccount': 'UserController.deleteAccount',


### PR DESCRIPTION
Adds a `POST /editAccountInfo` endpoint that accepts array parameters `friendCodes`, `inGameNames`, and `trainerShinyValues`.

See [the unit tests](/porygonco/porybox/blob/2a0e7cfb811e9095fc9cd71f068f7b92bd35b95a/test/controller/user.js#L187) for examples/validations.