### PR TITLE
Avoid race conditions in the tests for download counts

### DIFF
--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -270,18 +270,21 @@ describe('PokemonController', () => {
     it('increases the download count with downloads by third parties', async () => {
       const initialCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       await otherAgent.get(`/p/${publicPkmn.id}/download`);
+      await Promise.delay(500);
       const newCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       expect(newCount).to.equal(initialCount + 1);
     });
     it('increases the download count with downloads by unauthenticated users', async () => {
       const initialCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       await noAuthAgent.get(`/p/${publicPkmn.id}/download`);
+      await Promise.delay(500);
       const newCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       expect(newCount).to.equal(initialCount + 1);
     });
     it("does not increase the download count with downloads by a pokemon's owner", async () => {
       const initialCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       await agent.get(`/p/${publicPkmn.id}/download`);
+      await Promise.delay(500);
       const newCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       expect(newCount).to.equal(initialCount);
     });
@@ -292,6 +295,7 @@ describe('PokemonController', () => {
       await adminAgent.get(`/p/${publicPkmn.id}/download`);
       await adminAgent.get(`/p/${readonlyPkmn.id}/download`);
       await adminAgent.get(`/p/${privatePkmn.id}/download`);
+      await Promise.delay(500);
       const finalPublicCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
       const finalReadonlyCount = (await agent.get(`/p/${readonlyPkmn.id}`)).body.downloadCount;
       const finalPrivateCount = (await agent.get(`/p/${privatePkmn.id}`)).body.downloadCount;


### PR DESCRIPTION
We update the download count *after* returning a 200 response, since there's no reason to slow down the response time for a side-effect. However, this was causing the tests to occasionally fail because the next request would come in before the download count was finished updating.

(This is causing all our unit tests to fail on travis for some reason, so it would probably be best to merge this before looking at other stuff. I'm not really sure why they're failing consistently now, when they only rarely failed before -- maybe travis changed something internally with database connections.)