### PR TITLE
Allow a box's contents to be rearranged

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -12,6 +12,7 @@
     'PokemonNote': true,
     'CatchAsyncErrors': true,
     'Validation': true,
-    'DeletedUser': true
+    'DeletedUser': true,
+    'BoxOrdering': true
   }
 }

--- a/api/controllers/BoxController.js
+++ b/api/controllers/BoxController.js
@@ -37,6 +37,7 @@ module.exports = _.mapValues({
     if (!box) {
       return res.notFound();
     }
+    box.contents = BoxOrdering.getOrderedPokemonList(box);
     if (req.user && (box.owner === req.user.name || req.user.isAdmin)) {
       return res.ok(box.omitDeletedContents());
     }

--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -118,6 +118,14 @@ module.exports = _.mapValues({
     }
   },
 
+  /**
+  * Moves a Pokémon from one box to another, or to a different location within a box.
+  * POST /p/:id/move
+  * @param {string} id The ID of the Pokémon that should be moved
+  * @param {string} box The ID of the box that the Pokémon should be moved to.
+  * @param {number} [index] The index where the Pokémon should be inserted in the new box. If omitted, the
+  Pokémon is inserted at the end of the box.
+  */
   async move (req, res) {
     const params = req.allParams();
     Validation.requireParams(params, ['id', 'box']);
@@ -128,11 +136,25 @@ module.exports = _.mapValues({
     if (pokemon.owner !== newBox.owner) {
       return res.forbidden();
     }
-    const oldBox = await Box.findOne({id: pokemon.box});
+    const index = _.has(params, 'index') ? params.index : newBox._orderedIds.length;
+    if (!_.isNumber(index) || index % 1 || !_.inRange(index, newBox._orderedIds.length + 1)) {
+      return res.badRequest('Invalid index parameter');
+    }
+
+    let itemsToSave, oldBox;
+    if (params.box === pokemon.box) {
+      oldBox = newBox;
+      itemsToSave = [pokemon, newBox];
+    } else {
+      oldBox = await Box.findOne({id: pokemon.box});
+      itemsToSave = [pokemon, newBox, oldBox];
+    }
+
     _.remove(oldBox._orderedIds, id => id === pokemon.id);
-    newBox._orderedIds.push(pokemon.id);
     pokemon.box = newBox.id;
-    await Promise.all([pokemon.save(), oldBox.save(), newBox.save()]);
+    newBox._orderedIds.splice(index, 0, pokemon.id);
+
+    await Promise.all(itemsToSave.map(item => item.save()));
     return res.ok();
   },
   async addNote (req, res) {

--- a/api/models/Box.js
+++ b/api/models/Box.js
@@ -24,6 +24,14 @@ module.exports =  {
       via: 'box',
       defaultsTo: []
     },
+    /* Stores the list of Pokémon IDs that this box contains, in the order that they should be displayed to the user.
+    Note: This should never be sent to the client (especially to someone other than the box owner), because this
+    will contain the IDs of private Pokémon in a box, leaking their existence. (Since this property starts with a '_',
+    it is not included in JSON responses anyway -- see the toJSON method in this model.) */
+    _orderedIds: {
+      type: 'array',
+      defaultsTo: []
+    },
     id: {
       type: 'string',
       unique: true,

--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -142,6 +142,9 @@ const attributes = {
   async destroy () {
     const notes = (await Pokemon.findOne({id: this.id}).populate('notes')).notes;
     await Promise.each(notes, note => note.destroy());
+    const box = await Box.findOne({id: this.box});
+    _.remove(box.orderedIds, id => id === this.id);
+    await box.save();
     return await Pokemon.destroy({id: this.id});
   },
   toJSON () {

--- a/api/services/BoxOrdering.js
+++ b/api/services/BoxOrdering.js
@@ -1,0 +1,18 @@
+// polyfill lodash.keyBy, which was introduced in lodash 4, since sails only exposes lodash 3.
+const keyBy = (collection, iteratee) => _.mapValues(_.groupBy(collection, iteratee), 0);
+module.exports = {
+  getOrderedPokemonList (box) {
+    const pokemonMapById = keyBy(box.contents, 'id');
+    const orderedList = [];
+    _.forEach(box._orderedIds, id => {
+      if (_.isString(id) && id in pokemonMapById) {
+        if (!pokemonMapById[id]._markedForDeletion) {
+          orderedList.push(pokemonMapById[id]);
+        }
+      } else {
+        sails.log.warn(`Pokemon ${id} is in box ${box.id}, but is not on its ordered ID list.`);
+      }
+    });
+    return orderedList;
+  }
+};

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -150,6 +150,7 @@ describe('BoxController', () => {
     it('does not leak internal properties of a box to the client', async () => {
       const box = (await agent.get(`/b/${box1Id}`)).body;
       expect(box._markedForDeletion).to.not.exist;
+      expect(box._orderedIds).to.not.exist;
     });
   });
   describe('deleting a box', function () {


### PR DESCRIPTION
This updates the `POST /p/:id/move` endpoint to also accept an `index` parameter indicating the index at which a Pokémon should be inserted in the box.

Fixes the serverside portion of #20