### PR TITLE
Add parsed data such as species names to server responses

### DIFF
--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -57,7 +57,7 @@ module.exports = _.mapValues({
       return res.notFound();
     }
     pokemon.isUnique = await pokemon.checkIfUnique();
-    pokemon.pidHint = pokemon.pid >>> 16;
+    pokemon.assignParsedNames();
     const pokemonIsPublic = pokemon.visibility === 'public';
     const userIsOwner = !!req.user && req.user.name === pokemon.owner;
     const userIsAdmin = !!req.user && req.user.isAdmin;

--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -1,3 +1,4 @@
+const pk6parse = require('pk6parse');
 const attributes = {
   dexNo: {},
   heldItemId: {},
@@ -148,6 +149,10 @@ const attributes = {
     Conveniently, this means that the internal properties are never sent to the client.
     (Not to be confused with the omitPrivateData function, which removes *confidential* data.) */
     return _.omit(this, (value, key) => key.startsWith('_'));
+  },
+  assignParsedNames () {
+    this.pidHint = this.pid >>> 16;
+    return pk6parse.assignReadableNames(this);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "passport": "^0.3.2",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
-    "pk6parse": "^0.6.1",
+    "pk6parse": "^0.6.2",
     "rc": "1.0.1",
     "sails": "0.12.3",
     "sails-disk": "0.10.9",

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -66,17 +66,23 @@ describe('PokemonController', () => {
       const res = await otherAgent.get(`/p/${publicId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.pid).to.exist;
+      expect(res.body.speciesName).to.equal('Pelipper');
+      expect(res.body.abilityName).to.equal('Keen Eye');
+      expect(res.body.natureName).to.equal('Rash');
+      expect(res.body.move1Name).to.equal('Agility');
     });
     it('allows the uploader to view all the data on a readonly pokemon', async () => {
       const res = await agent.get(`/p/${readOnlyId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.pid).to.exist;
+      expect(res.body.speciesName).to.exist;
     });
     it('allows third parties to view only public data on a readonly pokemon', async () => {
       const res = await otherAgent.get(`/p/${readOnlyId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist;
       expect(res.body.pid).to.not.exist;
+      expect(res.body.speciesName).to.exist;
       expect(res.body.pidHint).to.exist;
       expect(res.body.pidHint).to.be.below(0x10000);
     });
@@ -84,6 +90,7 @@ describe('PokemonController', () => {
       const res = await agent.get(`/p/${privateId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.pid).to.exist;
+      expect(res.body.speciesName).to.exist;
     });
     it('does not allow third parties to view a private pokemon', async () => {
       const res = await otherAgent.get(`/p/${privateId}`);
@@ -94,18 +101,21 @@ describe('PokemonController', () => {
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist;
       expect(res.body.pid).to.exist;
+      expect(res.body.speciesName).to.exist;
     });
     it('allows an admin to view all the data on a readonly pokemon', async () => {
       const res = await adminAgent.get(`/p/${readOnlyId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist;
       expect(res.body.pid).to.exist;
+      expect(res.body.speciesName).to.exist;
     });
     it('allows an admin to view all the data on a private pokemon', async () => {
       const res = await adminAgent.get(`/p/${privateId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist;
       expect(res.body.pid).to.exist;
+      expect(res.body.speciesName).to.exist;
     });
     it("can return a list of all the requester's pokemon", async () => {
       const res = await agent.get('/pokemon/mine');


### PR DESCRIPTION
This way we won't have to send large JSON files to the client in order to map a dex number to a species name, etc.