### PR TITLE
Don't transpile serverside code more than necessary

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
-	"presets": ["es2015"],
-	"plugins": [
-		"transform-async-to-generator"
-	]
+	"plugins": ["transform-async-to-generator"]
 }

--- a/app.js
+++ b/app.js
@@ -25,8 +25,6 @@ process.chdir(__dirname);
 
 // Ensure a "sails" can be located:
 (function() {
-  require('babel-register')();
-  require('babel-polyfill');
   global.Promise = require('bluebird');
   let sails;
   try {

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,6 @@
+{
+	"presets": ["es2015"],
+	"plugins": [
+		"transform-async-to-generator"
+	]
+}


### PR DESCRIPTION
The only babel feature that we're actually using serverside is async functions. Everything else now works natively anyway, and we're hurting performance by transpiling it.

The client still uses babel-preset-es2015 for browser compatibility.