### PR TITLE
Avoid polluting the global namespace with bluebird Promise

### DIFF
--- a/api/services/Promise.js
+++ b/api/services/Promise.js
@@ -1,0 +1,1 @@
+module.exports = require('bluebird');

--- a/app.js
+++ b/app.js
@@ -25,7 +25,6 @@ process.chdir(__dirname);
 
 // Ensure a "sails" can be located:
 (function() {
-  global.Promise = require('bluebird');
   let sails;
   try {
     sails = require('sails');


### PR DESCRIPTION
Using a service is better because it still allows us to reference it without having to redefine it at the top of every file, but we don't affect other modules that use Promises.