### PR TITLE
Remove unnecessary babel from tests

### DIFF
--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -6,8 +6,6 @@ before(function(done) {
   // Increase the Mocha timeout so that Sails has enough time to lift.
   this.timeout(10000);
   require('babel-register')();
-  require('babel-polyfill');
-  global.Promise = require('bluebird');
 
   sails.lift({
     environment: 'test',


### PR DESCRIPTION
This is the same as those other two PRs from before (#124 and #125), but I forgot to remove the code from the test start file when I removed it from the `app.js` file.