### PR TITLE
Prevent sails from crashing on startup

### DIFF
--- a/api/services/Promise.js
+++ b/api/services/Promise.js
@@ -1,1 +1,6 @@
-module.exports = require('bluebird');
+'use strict';
+const Promise = require('bluebird');
+if (sails.config.environment === 'development') {
+  Promise.config({longStackTraces: true});
+}
+module.exports = Promise;

--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ process.chdir(__dirname);
 
 // Ensure a "sails" can be located:
 (function() {
+  require('babel-register')();
   let sails;
   try {
     sails = require('sails');

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -11,7 +11,6 @@
  */
 
 // This causes a performance hit so it shouldn't be used in production, but it's very useful for debugging in development.
-Promise.config({longStackTraces: true});
 
 module.exports = {
 


### PR DESCRIPTION
So it seems like I missed a few things in PRs #123 and #124.

The first issue is that our tests run from the sails configuration in `test/bootstrap.test.js` whereas our normal configuration is in `app.js`. #123 and #124 modified `app.js`, but they never modified `test/bootstrap.test.js`.

This was a problem because our tests were passing (since the config for them hadn't been changed), but the change actually caused a crash on `npm start` and we didn't notice. #129 updates `test/bootstrap.test.js` to be consistent with `app.js`.

Anyway, this PR fixes those issues. The first is that we were using `Promise.config` (a bluebird feature) in `config/env/development`, which gets loaded before the `Promise` service, so it was throwing a `Promise.config is not a function` error. This was fixed by moving the `Promise.config` statement to the `services/Promise.js` file itself.

The other issue was that `babel-register` is actually required even though we're not using as much babel as we were previously, so I added that back.