### PR TITLE
Load the CSS properly when viewing a page with a complex pathname

### DIFF
--- a/client/layout.ejs
+++ b/client/layout.ejs
@@ -5,7 +5,7 @@
 
     <!-- Viewport mobile tag for sensible mobile support -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <link rel="stylesheet" href="bundle.css" />
+    <link rel="stylesheet" href="/bundle.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" type="text/css">
   </head>


### PR DESCRIPTION
Currently, the header bar fails to load on any URI that contains a slash after the domain, e.g. `localhost:1337/p/abcdefabcdef`.