### PR TITLE
Require the client to specify a box on upload (fixes #128)

### DIFF
--- a/api/services/BoxOrdering.js
+++ b/api/services/BoxOrdering.js
@@ -5,12 +5,8 @@ module.exports = {
     const pokemonMapById = keyBy(box.contents, 'id');
     const orderedList = [];
     _.forEach(box._orderedIds, id => {
-      if (_.isString(id) && id in pokemonMapById) {
-        if (!pokemonMapById[id]._markedForDeletion) {
-          orderedList.push(pokemonMapById[id]);
-        }
-      } else {
-        sails.log.warn(`Pokemon ${id} is in box ${box.id}, but is not on its ordered ID list.`);
+      if (_.isString(id) && _.has(pokemonMapById, id) && !pokemonMapById[id]._markedForDeletion) {
+        orderedList.push(pokemonMapById[id]);
       }
     });
     return orderedList;

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -189,9 +189,8 @@ describe('AuthController', function() {
       });
       expect(res.statusCode).to.equal(200);
       // do another request to make sure the current user is still authenticated
-      const res2 = await passAgent.post('/uploadpk6').attach('pk6', `${__dirname}/pkmn1.pk6`);
+      const res2 = await passAgent.post('/box').send({name: 'Soapbox'});
       expect(res2.statusCode).to.equal(201);
-      expect(res2.body.pid).to.exist;
       // log in with a different agent to make sure the new password works
       const res3 = await passAgent2.post('/auth/local').send({
         identifier: username,
@@ -241,9 +240,8 @@ describe('AuthController', function() {
       });
       expect(res.statusCode).to.equal(200);
       // do another request to make sure the current user is still authenticated
-      const res2 = await passAgent.post('/uploadpk6').attach('pk6', `${__dirname}/pkmn1.pk6`);
+      const res2 = await passAgent.post('/box').send({name: 'Outbox'});
       expect(res2.statusCode).to.equal(201);
-      expect(res2.body.pid).to.exist;
       // log in with a different agent to make sure the password still works
       const res3 = await passAgent2.post('/auth/local').send({
         identifier: username,
@@ -259,9 +257,8 @@ describe('AuthController', function() {
       });
       expect(res.statusCode).to.equal(400);
       // do another request to make sure the current user is still authenticated
-      const res2 = await passAgent.post('/uploadpk6').attach('pk6', `${__dirname}/pkmn1.pk6`);
+      const res2 = await passAgent.post('/box').send({name: 'PO Box'});
       expect(res2.statusCode).to.equal(201);
-      expect(res2.body.pid).to.exist;
       // log in with a different agent to make sure the old password still works
       const res3 = await passAgent2.post('/auth/local').send({
         identifier: username,


### PR DESCRIPTION
This PR:

* Causes the server to return a 400 error if the client does not specify a box while uploading, as decided in #128
* Fixes all the tests that broke as a result of this change