### PR TITLE
Send parsed box contents when viewing a box page

### DIFF
--- a/api/controllers/BoxController.js
+++ b/api/controllers/BoxController.js
@@ -37,7 +37,7 @@ module.exports = _.mapValues({
     if (!box) {
       return res.notFound();
     }
-    box.contents = BoxOrdering.getOrderedPokemonList(box);
+    box.contents = BoxOrdering.getOrderedPokemonList(box).map(pkmn => pkmn.assignParsedNames());
     if (req.user && (box.owner === req.user.name || req.user.isAdmin)) {
       return res.ok(box.omitDeletedContents());
     }

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -60,16 +60,21 @@ describe('BoxController', () => {
       expect(box.id).to.equal(boxId);
       expect(box.contents).to.have.lengthOf(3);
       expect(box.contents[0].pid).to.exist;
+      expect(box.contents[0].speciesName).to.exist;
       expect(box.contents[1].pid).to.exist;
+      expect(box.contents[1].speciesName).to.exist;
       expect(box.contents[2].pid).to.exist;
+      expect(box.contents[2].speciesName).to.exist;
     });
     it('allows third parties to view a box, filtering contents by pokemon visibility', async () => {
       const box = (await otherAgent.get(`/b/${boxId}`)).body;
       expect(box.id).to.equal(boxId);
       expect(box.contents[0].visibility).to.equal('readonly');
       expect(box.contents[0].pid).to.not.exist;
+      expect(box.contents[0].speciesName).to.exist;
       expect(box.contents[1].visibility).to.equal('public');
       expect(box.contents[1].pid).to.exist;
+      expect(box.contents[1].speciesName).to.exist;
       expect(box.contents[2]).to.not.exist;
     });
     it('allows admins to view the full contents of a box by ID', async () => {
@@ -77,10 +82,13 @@ describe('BoxController', () => {
       expect(box.id).to.equal(boxId);
       expect(box.contents[0].visibility).to.equal('readonly');
       expect(box.contents[0].pid).to.exist;
+      expect(box.contents[0].speciesName).to.exist;
       expect(box.contents[1].visibility).to.equal('public');
       expect(box.contents[1].pid).to.exist;
+      expect(box.contents[1].speciesName).to.exist;
       expect(box.contents[2].visibility).to.equal('private');
-      expect(box.contents[2].visibility).to.exist;
+      expect(box.contents[2].pid).to.exist;
+      expect(box.contents[2].speciesName).to.exist;
     });
     it('allows an unauthenticated user to view a box by ID', async () => {
       const res = await noAuthAgent.get(`/b/${boxId}`);
@@ -89,8 +97,10 @@ describe('BoxController', () => {
       expect(box.id).to.equal(boxId);
       expect(box.contents[0].visibility).to.equal('readonly');
       expect(box.contents[0].pid).to.not.exist;
+      expect(box.contents[0].speciesName).to.exist;
       expect(box.contents[1].visibility).to.equal('public');
-      expect(box.contents[1].visibility).to.exist;
+      expect(box.contents[1].pid).to.exist;
+      expect(box.contents[1].speciesName).to.exist;
       expect(box.contents[2]).to.not.exist;
     });
   });


### PR DESCRIPTION
This adds properties like `speciesName` and `level` to te server's response when viewing a box.