### PR TITLE
Fix pokemon tests

### DIFF
--- a/client/pokemon/pokemon.spec.js
+++ b/client/pokemon/pokemon.spec.js
@@ -28,7 +28,8 @@ describe('PokemonCtrl', function() {
         dexNo: 'pokemonDexNo',
         owner: 'boxUser',
         id: 'pokemonId',
-        isShiny: false
+        isShiny: false,
+        tid: 1, sid: 1, esv: 1, tsv: 1
       }});
       tested.parseProps();
       expect(tested.data.nickname).to.equal('pokemondNickname');
@@ -44,29 +45,35 @@ describe('PokemonCtrl', function() {
         $scope: $scope,
         io: io, $routeParams:
         $routeParams
-      }, {});
+      }, {data: {tid: 1, sid: 1, esv: 1, tsv: 1}});
       tested.parseProps();
       expect(tested.id).to.equal('routeParamId');
-      expect(Object.keys(tested.data).length).to.equal(0);
+      expect(Object.keys(tested.data).length).to.equal(4);
     });
 
     it("pads a Pokémon's TID correctly", function() {
-      const tested1 = $controller(ctrlTest, {$scope, io, $routeParams}, {data: {tid: 12345}});
+      const tested1 = $controller(ctrlTest, {$scope, io, $routeParams},
+        {data: {tid: 12345, sid: 1, esv: 1, tsv: 1}});
       tested1.parseProps();
       expect(tested1.paddedTid).to.equal('12345');
-      const tested2 = $controller(ctrlTest, {$scope, io, $routeParams}, {data: {tid: 1234}});
+      const tested2 = $controller(ctrlTest, {$scope, io, $routeParams},
+        {data: {tid: 1234, sid: 1, esv: 1, tsv: 1}});
       tested2.parseProps();
       expect(tested2.paddedTid).to.equal('01234');
-      const tested3 = $controller(ctrlTest, {$scope, io, $routeParams}, {data: {tid: 123}});
+      const tested3 = $controller(ctrlTest, {$scope, io, $routeParams},
+        {data: {tid: 123, sid: 1, esv: 1, tsv: 1}});
       tested3.parseProps();
       expect(tested3.paddedTid).to.equal('00123');
-      const tested4 = $controller(ctrlTest, {$scope, io, $routeParams}, {data: {tid: 12}});
+      const tested4 = $controller(ctrlTest, {$scope, io, $routeParams},
+        {data: {tid: 12, sid: 1, esv: 1, tsv: 1}});
       tested4.parseProps();
       expect(tested4.paddedTid).to.equal('00012');
-      const tested5 = $controller(ctrlTest, {$scope, io, $routeParams}, {data: {tid: 1}});
+      const tested5 = $controller(ctrlTest, {$scope, io, $routeParams},
+        {data: {tid: 1, sid: 1, esv: 1, tsv: 1}});
       tested5.parseProps();
       expect(tested5.paddedTid).to.equal('00001');
-      const tested6 = $controller(ctrlTest, {$scope, io, $routeParams}, {data: {tid: 0}});
+      const tested6 = $controller(ctrlTest, {$scope, io, $routeParams},
+        {data: {tid: 0, sid: 1, esv: 1, tsv: 1}});
       tested6.parseProps();
       expect(tested6.paddedTid).to.equal('00000');
     });


### PR DESCRIPTION
Let's make sure we always make PRs for changes, even if they are small ones, even if we are just going to merge them ourselves, so we don't break master.

Anyway, @not-an-aardvark is there any case that these will be undefined except in the tests? Do we want to put a check in for them? I assume there should never be a situation where this occurs, we will always have tid, sid, tsv and esv in the real world?