### PR TITLE
Fix concurrency issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ node_js:
   - "stable"
 services:
   - mongodb
+addons:
+  apt:
+    sources:
+    - mongodb-3.0-precise
+    packages:
+    - mongodb-org-server

--- a/api/controllers/BoxController.js
+++ b/api/controllers/BoxController.js
@@ -72,9 +72,8 @@ module.exports = _.mapValues({
     const filteredParams = Validation.filterParams(params, ['name', 'description', 'visibility']);
     const box = await Box.findOne({id: params.id});
     Validation.verifyUserIsOwner(box, req.user);
-    _.assign(box, filteredParams);
-    Validation.verifyBoxParams(box);
-    await box.save();
+    Validation.verifyBoxParams(filteredParams);
+    await Box.update({id: box.id}, filteredParams);
     return res.ok(box);
   }
 }, catchAsyncErrors);

--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -39,8 +39,6 @@ module.exports = _.mapValues({
     }
     const result = await Pokemon.create(parsed);
     result.isUnique = await result.checkIfUnique();
-    box._orderedIds.push(result.id);
-    await box.save();
     return PokemonHandler.getSafePokemonForUser(result, req.user).then(res.created);
   },
 
@@ -99,8 +97,7 @@ module.exports = _.mapValues({
     }
     res.status(200).json(pokemon._rawPk6);
     if (!userIsOwner && pokemon.visibility === 'public') {
-      pokemon.downloadCount++;
-      await pokemon.save();
+      await pokemon.incrementDownloadCount();
     }
   },
 
@@ -138,26 +135,27 @@ module.exports = _.mapValues({
       return res.badRequest('Invalid index parameter');
     }
 
-    let itemsToSave, oldBox;
+    let oldBox;
     if (params.box === pokemon.box) {
       oldBox = newBox;
-      itemsToSave = [pokemon, newBox];
       _.remove(orderedContents, pkmn => pkmn.id === pokemon.id);
     } else {
       oldBox = await Box.findOne({id: pokemon.box});
-      itemsToSave = [pokemon, newBox, oldBox];
     }
 
     _.remove(oldBox._orderedIds, id => id === pokemon.id);
-    pokemon.box = newBox.id;
     /* If the new box contains deleted items, the provided index of the new pokemon of the orderedContents list might not be
     the same as the index of the new pokemon in the _orderedIds list, since the _orderedIds list also contains the IDs of
     deleted contents. To fix the issue, take the pokemon ID that the new pokemon will immediately follow in the orderedContents
     list, and place the new pokemon right after that ID in the _orderedIds list. */
     const adjIndex = index > 0 ? newBox._orderedIds.indexOf(orderedContents[index - 1].id) + 1 : 0;
-    newBox._orderedIds.splice(adjIndex, 0, pokemon.id);
-
-    await Promise.all(itemsToSave.map(item => item.save()));
+    await oldBox.removePkmnId(pokemon.id);
+    pokemon.box = newBox.id;
+    const promises = [
+      newBox.addPkmnId(pokemon.id, adjIndex),
+      Pokemon.update({id: pokemon.id}, {box: newBox.id})
+    ];
+    await Promise.all(promises);
     return res.ok();
   },
   async addNote (req, res) {
@@ -207,9 +205,8 @@ module.exports = _.mapValues({
     if (!note) {
       return res.notFound();
     }
-    _.assign(note, filteredParams);
-    Validation.verifyPokemonNoteParams(note);
-    await note.save();
+    Validation.verifyPokemonNoteParams(filteredParams);
+    await PokemonNote.update({id: note.id}, filteredParams);
     return res.ok(note);
   },
 
@@ -219,9 +216,8 @@ module.exports = _.mapValues({
     const filteredParams = Validation.filterParams(params, ['visibility']);
     const pokemon = await Pokemon.findOne({id: params.id});
     Validation.verifyUserIsOwner(pokemon, req.user);
-    _.assign(pokemon, filteredParams);
-    Validation.verifyPokemonParams(pokemon);
-    await pokemon.save();
+    Validation.verifyPokemonParams(filteredParams);
+    await Pokemon.update({id: pokemon.id}, filteredParams);
     return res.ok(pokemon);
   }
 }, catchAsyncErrors);

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -49,30 +49,31 @@ module.exports = _.mapValues({
     Validation.assert(_.every(filteredParams, _.isArray), 'Parameters must be arrays');
     const hasNoDupes = arr => _.uniq(arr).length === arr.length;
     Validation.assert(_.every(filteredParams, hasNoDupes), 'Arrays must not have duplicate values');
-    _.assign(req.user, filteredParams);
     try {
-      await req.user.save();
+      await User.update({name: req.user.name}, filteredParams);
     } catch (err) {
       return err.code === 'E_VALIDATION' ? res.badRequest() : res.serverError(err);
     }
     return res.ok();
   },
   async grantAdminStatus (req, res) {
-    const user = await User.findOne({name: req.param('name')});
+    const params = req.allParams();
+    Validation.requireParams(params, 'name');
+    const user = await User.findOne({name: params.name});
     if (!user) {
       return res.notFound();
     }
-    user.isAdmin = true;
-    await user.save();
+    await User.update({name: params.name}, {isAdmin: true});
     return res.ok();
   },
   async revokeAdminStatus (req, res) {
-    const user = await User.findOne({name: req.param('name')});
+    const params = req.allParams();
+    Validation.requireParams(params, 'name');
+    const user = await User.findOne({name: params.name});
     if (!user) {
       return res.notFound();
     }
-    user.isAdmin = false;
-    await user.save();
+    await User.update({name: params.name}, {isAdmin: false});
     return res.ok();
   },
   async deleteAccount (req, res) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -68,6 +68,21 @@ module.exports =  {
     omitPrivateInformation () {
       return _.omit(this, ['passports', 'email', 'preferences', 'updatedAt']);
     },
+    addBoxId (id, position) {
+      return Promise.fromCallback(User.native.bind(User)).then(collection => {
+        const query = {$push: {_orderedBoxIds: {$each: [id]}}};
+        if (_.isNumber(position)) {
+          query.$push._orderedBoxIds.$position = position;
+        }
+        return collection.update({_id: this.name}, query);
+      });
+    },
+
+    removeBoxId (id) {
+      return Promise.fromCallback(User.native.bind(User)).then(collection => {
+        return collection.update({_id: this.name}, {$pull: {_orderedBoxIds: id}});
+      });
+    },
     async deleteAccount () {
       await Promise.all([
         UserPreferences.destroy({user: this.name}),

--- a/api/services/Validation.js
+++ b/api/services/Validation.js
@@ -6,9 +6,9 @@ module.exports = {
     }
     return filtered;
   },
-  requireParams (allParams, requiredValues) {
+  requireParams (allParams, requiredValues, {requireStrings = true} = {}) {
     _.forEach(_.isArray(requiredValues) ? requiredValues : [requiredValues], param => {
-      if (!_.has(allParams, param)) {
+      if (!_.has(allParams, param) || requireStrings && !_.isString(allParams[param])) {
         throw {statusCode: 400, message: `Missing parameter ${param}`};
       }
     });
@@ -23,27 +23,30 @@ module.exports = {
       throw {statusCode: item._markedForDeletion ? 404 : 403};
     }
   },
-  verifyBoxParams (box) {
-    if (!_.isString(box.name) || _.isEmpty(box.name)) {
+  verifyBoxParams (params) {
+    if (!_.isUndefined(params.name) && (!_.isString(params.name) || _.isEmpty(params.name))) {
       throw {statusCode: 400, message: 'Invalid box name'};
     }
-    if (box.description && !_.isString(box.description)) {
+    if (!_.isUndefined(params.name) && (params.description && !_.isString(params.description))) {
       throw {statusCode: 400, message: 'Invalid box description'};
     }
-    if (!Constants.BOX_VISIBILITIES.includes(box.visibility)) {
+    if (!_.isUndefined(params.visibility)
+        && !Constants.BOX_VISIBILITIES.includes(params.visibility)) {
       throw {statusCode: 400, message: 'Invalid box visibility'};
     }
   },
-  verifyPokemonParams (pokemon) {
-    if (!Constants.POKEMON_VISIBILITIES.includes(pokemon.visibility)) {
+  verifyPokemonParams (params) {
+    if (!_.isUndefined(params.visibility)
+        && !Constants.POKEMON_VISIBILITIES.includes(params.visibility)) {
       throw {statusCode: 400, message: 'Invalid pokemon visibility'};
     }
   },
-  verifyPokemonNoteParams (note) {
-    if (!_.isString(note.text) || _.isEmpty(note.text)) {
+  verifyPokemonNoteParams (params) {
+    if (!_.isUndefined(params.text) && (!_.isString(params.text) || _.isEmpty(params.text))) {
       throw {statusCode: 400, message: 'Invalid note text'};
     }
-    if (!Constants.POKEMON_NOTE_VISIBILITIES.includes(note.visibility)) {
+    if (!_.isUndefined(params.visibility)
+        && !Constants.POKEMON_NOTE_VISIBILITIES.includes(params.visibility)) {
       throw {statusCode: 400, message: 'Invalid note visibility'};
     }
   },

--- a/api/services/catchAsyncErrors.js
+++ b/api/services/catchAsyncErrors.js
@@ -1,5 +1,5 @@
 module.exports = func => (req, res) => Promise.method(func)(req, res).catch(err => {
-  if (res.finished) {
+  if (res.headersSent) {
     return sails.log.error(err);
   }
   if (!_.isError(err) && err.statusCode) {

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -212,12 +212,13 @@ describe('BoxController', () => {
       pkmn = res2.body;
     });
     it('does not allow a user to delete their last box', async () => {
-      for (let i = 0; i < 5; i++) {
+      const initialLength = (await agent.get('/user/boxtester/boxes')).body.length;
+      await Promise.all(_.times(5, async () => {
         const res = await agent.post('/box').send({name: 'Fare Box'});
         expect(res.statusCode).to.equal(201);
-      }
+      }));
       const res2 = await agent.get('/user/boxtester/boxes');
-      expect(res2.body.length).to.be.at.least(5);
+      expect(res2.body.length).to.equal(initialLength + 5);
       expect(res2.statusCode).to.equal(200);
       await Promise.each(res2.body.slice(1), async box => {
         const res3 = await agent.del(`/b/${box.id}`);


### PR DESCRIPTION
Fixes #157

tl;dr We should avoid using waterline's `.save()` method for database models, and instead use .update() to make updates to the database. If a document is modified between the time that it is fetched and `.save()` is called, the changes will be overwritten by `.save()` but not by `.update()`.

There is still the possibility of leaving the database in an inconsistent state if connection is randomly lost (which is sort of difficult to avoid since mongo doesn't have transactions), but there shouldn't be any more race condition issues now.