### PR TITLE
Omit server-only properties from user profile responses

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -91,6 +91,9 @@ module.exports =  {
       ]);
       await User.destroy({name: this.name});
       await DeletedUser.create({name: this.name});
+    },
+    toJSON () {
+      return _.omit(this, (value, key) => key.startsWith('_'));
     }
   }
 };

--- a/test/controller/user.js
+++ b/test/controller/user.js
@@ -76,6 +76,17 @@ describe('UserController', () => {
       expect(res.body.inGameNames).to.exist();
       expect(res.body.trainerShinyValues).exist();
     });
+    it('omits server-only properties when anyone gets the profile', async () => {
+      const res = await agent.get('/user/usertester');
+      expect(res.statusCode).to.equal(200);
+      expect(res.body._orderedBoxIds).to.not.exist();
+      const res2 = await adminAgent.get('/user/usertester');
+      expect(res2.statusCode).to.equal(200);
+      expect(res2.body._orderedBoxIds).to.not.exist();
+      const res3 = await noAuthAgent.get('/user/usertester');
+      expect(res3.statusCode).to.equal(200);
+      expect(res3.body._orderedBoxIds).to.not.exist();
+    });
   });
   describe('preferences', () => {
     it("can get a user's preferences", async () => {


### PR DESCRIPTION
This was allowing anyone to see a user's unlisted boxes in the `_orderedBoxIds` array by going to the `/user/theUsername` endpoint.