### PR TITLE
Refactor login

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -80,8 +80,7 @@ module.exports = _.mapValues({
     const params = req.allParams();
     Validation.requireParams(params, 'password');
     const userPassport = await Passport.findOne({user: req.user.name, protocol: 'local'});
-    const validate = userPassport.validatePassword.bind(userPassport);
-    const isValid = await Promise.promisify(validate)(params.password);
+    const isValid = await userPassport.validatePassword(params.password);
     if (!isValid) {
       return res.forbidden('Incorrect password');
     }
@@ -92,8 +91,7 @@ module.exports = _.mapValues({
     const params = req.allParams();
     Validation.requireParams(params, ['oldPassword', 'newPassword']);
     const oldPassport = await Passport.findOne({user: req.user.name, protocol: 'local'});
-    const validate = oldPassport.validatePassword.bind(oldPassport);
-    const isValid = await Promise.promisify(validate)(params.oldPassword);
+    const isValid = await oldPassport.validatePassword(params.oldPassword);
     if (!isValid) {
       // If the provided oldPassword is incorrect, stop immediately.
       return res.forbidden('Incorrect password');

--- a/api/models/Passport.js
+++ b/api/models/Passport.js
@@ -93,8 +93,8 @@ const Passport = {
      * @param {string}   password The password to validate
      * @param {Function} next
      */
-    validatePassword: function (password, next) {
-      bcrypt.compare(password, this.password, next);
+    validatePassword: function (password) {
+      return Promise.promisify(bcrypt.compare)(password, this.password);
     }
 
   },

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -275,11 +275,9 @@ passport.loadStrategies = function () {
     let Strategy;
 
     if (key === 'local') {
-      // Since we need to allow users to login using both usernames as well as
-      // emails, we'll set the username field to something more generic.
-      _.extend(options, { usernameField: 'identifier' });
 
-      //Let users override the username and passwordField from the options
+      _.extend(options, { usernameField: 'name' });
+
       _.extend(options, strategies[key].options || {});
 
       // Only load the local strategy if it's enabled in the config

--- a/client/login/login.ctrl.js
+++ b/client/login/login.ctrl.js
@@ -4,8 +4,8 @@
  */
 'use strict';
 const ERRORS_MAP = {
-  'Error.Passport.Password.Wrong': 'incorrect password',
-  'Error.Passport.Username.NotFound': 'incorrect username',
+  'Error.Passport.Password.Wrong': 'incorrect username/password combination',
+  'Error.Passport.Username.NotFound': 'incorrect username/password combination',
   'Error.Passport.Email.Missing': 'invalid email address',
   'Error.Passport.Password.Missing': 'missing password',
   'Error.Passport.Password.Invalid': 'invalid password (must be at least 8 characters long)',
@@ -38,7 +38,7 @@ module.exports = function ($scope, $http) {
       method: 'POST',
       url: '/auth/local',
       data: {
-        identifier: $scope.loginName,
+        name: $scope.loginName,
         password: $scope.loginPassword
       }
     }).then(() => {

--- a/client/login/login.module.js
+++ b/client/login/login.module.js
@@ -12,14 +12,14 @@ ng.module('porybox.login', ['ngRoute'])
   {
     bindings: {},
     templateUrl: 'login/login.view.html',
-    controller: controller,
+    controller: ['$scope', '$http', controller],
     controllerAs: 'auth'
   })
   .component('registrationForm',
   {
     bindings: {},
     templateUrl: 'login/register.view.html',
-    controller: controller,
+    controller: ['$scope', '$http', controller],
     controllerAs: 'auth'
   }).config(['$routeProvider', function ($routeProvider) {
     $routeProvider.when('/login', {

--- a/client/login/login.spec.js
+++ b/client/login/login.spec.js
@@ -20,7 +20,7 @@ describe('LoginCtrl', function() {
       const controller = $controller(loginCtrl, {$scope, $http: $http1});
       expect(controller.login).to.be.a('function');
       return controller.login().then(() => {
-        expect(controller.loginError).to.equal('incorrect password');
+        expect(controller.loginError).to.equal('incorrect username/password combination');
         expect(controller.registerError).to.not.be.ok();
       });
     });

--- a/client/login/login.view.html
+++ b/client/login/login.view.html
@@ -7,7 +7,7 @@
   <md-card-content>
     <form role="form" ng-submit="auth.login()">
       <md-input-container class="md-block">
-        <input type="text" name="identifier" ng-model="loginName">
+        <input type="text" name="username" ng-model="loginName">
         <label>Username</label>
       </md-input-container>
       <md-input-container class="md-block">

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -68,7 +68,7 @@ describe('AuthController', function() {
 
     it('should not allow logins with invalid passwords', async () => {
       const res = await otherAgent.post('/auth/local').send({
-        identifier: 'testuser1',
+        name: 'testuser1',
         password: 'not_the_correct_password'
       });
       expect(res.statusCode).to.equal(401);
@@ -84,7 +84,7 @@ describe('AuthController', function() {
       });
       expect(res.statusCode).to.equal(200);
       const res2 = await invalidAgent.post('/auth/local').send({
-        identifier: 'validUsername',
+        name: 'validUsername',
         // 71 asterisks followed by an 'a'
         password: '***********************************************************************a'
       });
@@ -94,7 +94,7 @@ describe('AuthController', function() {
 
     it('should allow logins with valid passwords', async () => {
       const res = await otherAgent.post('/auth/local').send({
-        identifier: 'testuser1',
+        name: 'testuser1',
         password: 'hunter22'
       });
       expect(res.statusCode).to.equal(200);
@@ -102,7 +102,7 @@ describe('AuthController', function() {
 
     it('should not allow logins with invalid user but the password of another', async () => {
       const res = await otherAgent.post('/auth/local').send({
-        identifier: 'testuser2',
+        name: 'testuser2',
         password: 'hunter22'
       });
       expect(res.statusCode).to.equal(401);
@@ -173,13 +173,13 @@ describe('AuthController', function() {
       expect(res2.statusCode).to.equal(201);
       // log in with a different agent to make sure the new password works
       const res3 = await passAgent2.post('/auth/local').send({
-        identifier: username,
+        name: username,
         password: 'Correct Llama Battery Staple'
       });
       expect(res3.statusCode).to.equal(200);
       // log in with the old password and make sure it doesn't work
       const res4 = await passAgent3.post('/auth/local').send({
-        identifier: username,
+        name: username,
         password: 'Correct Horse Battery Staple'
       });
       expect(res4.statusCode).to.equal(401);
@@ -193,13 +193,13 @@ describe('AuthController', function() {
       expect(res.statusCode).to.equal(403);
       // log in with the old password and make sure it still works
       const res2 = await passAgent2.post('/auth/local').send({
-        identifier: username,
+        name: username,
         password: 'Correct Horse Battery Staple'
       });
       expect(res2.statusCode).to.equal(200);
       // log in with the new password and make sure it doesn't work
       const res3 = await passAgent3.post('/auth/local').send({
-        identifier: username,
+        name: username,
         password: 'invalid new password'
       });
       expect(res3.statusCode).to.equal(401);
@@ -222,7 +222,7 @@ describe('AuthController', function() {
       expect(res2.statusCode).to.equal(201);
       // log in with a different agent to make sure the password still works
       const res3 = await passAgent2.post('/auth/local').send({
-        identifier: username,
+        name: username,
         password: 'Correct Horse Battery Staple'
       });
       expect(res3.statusCode).to.equal(200);
@@ -238,7 +238,7 @@ describe('AuthController', function() {
       expect(res2.statusCode).to.equal(201);
       // log in with a different agent to make sure the old password still works
       const res3 = await passAgent2.post('/auth/local').send({
-        identifier: username,
+        name: username,
         password: 'Correct Horse Battery Staple'
       });
       expect(res3.statusCode).to.equal(200);


### PR DESCRIPTION
We currently have a bit of Passport.js boilerplate in our authentication code that is supposed to allow for email login, even though we only allow logins with usernames. This caused our API to be inconsistent (e.g. we called a username an "identifier" on login, but a "name" on registration). Also, the code authentication endpoint was overcomplicated.

Anyway, now we explicitly only allow usernames for login.

This PR also refactors some of the boilerplate code from callbacks to use Promises instead.