### PR TITLE
Render the landing page before waiting for the js bundle to download

### DIFF
--- a/api/policies/passport.js
+++ b/api/policies/passport.js
@@ -31,6 +31,7 @@ module.exports = function (req, res, next) {
       // Make the user available throughout the frontend
       res.locals.user = req.user;
       res.locals.VERSION = VERSION;
+      res.locals.url = req.url;
       if (req.user) {
         Promise.all([
           User.findOne({name: req.user.name}).populate('boxes').then(BoxOrdering.getOrderedBoxList),

--- a/client/app.js
+++ b/client/app.js
@@ -36,7 +36,8 @@ const porybox = ng.module('porybox', [
   'angular-sortable-view'
 ]);
 
-porybox.controller('MainCtrl', function () {
+porybox.controller('MainCtrl', ['$rootScope', function ($rootScope) {
+  $rootScope.location = location;
   this.boxes = [];
   this.selected = {};
   this.init = function ({boxes, user, prefs, selectedBox}) {
@@ -48,7 +49,7 @@ porybox.controller('MainCtrl', function () {
     this.prefs = prefs;
     this.selected.box = selectedBox;
   };
-});
+}]);
 
 porybox.config(['$mdThemingProvider','$routeProvider',function(
   $mdThemingProvider,

--- a/client/home/main.view.html
+++ b/client/home/main.view.html
@@ -1,2 +1,1 @@
 <homepage ng-if="main.user" boxes="main.boxes" selected="main.selected"></homepage>
-<index ng-if="!main.user" ></index>

--- a/client/layout.ejs
+++ b/client/layout.ejs
@@ -33,6 +33,13 @@
       <div flex layout="column">
         <main>
           <%- body %>
+          <% if (user == null && url === '/') { %>
+            <!-- Render the landing page without angular to distract people with static content while the bundle downloads -->
+            <div id="landing-page" style="display:none;" ng-if="location.hash === '' || location.hash === '#/'">
+              <% include home/index.view.html %>
+            <div>
+            <script>if (location.hash === '' || location.hash === '#/') document.getElementById('landing-page').style.display = '';</script>
+          <% } %>
         </main>
         <div flex></div>
         <%- include footer.ejs %>


### PR DESCRIPTION
Fixes #201

This isn't exactly the cleanest optimization ever, but it should significantly speed up the load time for the landing page.

The complication is that while the server can tell whether a user is logged in, it can't tell whether the user is viewing the homepage (since it can't see the hash). So if the user is logged out, it always sends the landing page in a div with `display: none`, and there's a line of javascript that removes the `display: none` if the user is on the homepage.

The disadvantage is that if the logged-out user starts out somewhere other than the homepage, there will be a bit of extra html that gets sent without getting used. But I think this is probably still worth it given that (a) most users will start on the landing page, and (b) our bundle is going to be much larger than our landing page.