### PR TITLE
Update pk6parse to v0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "passport": "^0.3.2",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
-    "pk6parse": "^0.10.3",
+    "pk6parse": "^0.10.4",
     "rc": "1.1.6",
     "sails": "0.12.3",
     "sails-disk": "0.10.10",


### PR DESCRIPTION
Contains a partial fix for #226, although we will also need to change the view a bit.

`expToNextLevel` will now be `Infinity` for things at level 100 (although as far as the client is concerned, it will be `null` because `JSON.stringify(Infinity) === null`).