### PR TITLE
Add upload info dialog with notes

### DIFF
--- a/client/pokemon/pokemon-full.view.html
+++ b/client/pokemon/pokemon-full.view.html
@@ -23,15 +23,32 @@
           <i class="material-icons">file_download</i>
         </md-button>
       </a>
-      <md-button class="md-icon-button" aria-label="Pokémon settings" ng-click="pokemon.edit()"
-        ng-show="pokemon.data.owner === main.user.name || main.user.isAdmin">
-        <md-tooltip md-direction="left">{{pokemon.parsedNickname}}'s settings</md-tooltip>
-        <i class="material-icons">settings</i>
-      </md-button>
-      <md-button class="md-icon-button" aria-label="Delete Pokémon" ng-click="pokemon.delete()"
-        ng-show="pokemon.data.owner === main.user.name || main.user.isAdmin">
-        <md-tooltip md-direction="left">Delete {{pokemon.parsedNickname}}</md-tooltip>
-        <i class="material-icons">delete</i>
+      <md-menu md-position-mode="target-right target" md-offset="0 50">
+        <md-button class="md-icon-button" aria-label="Pokémon settings" ng-click="$mdOpenMenu($event)"
+          ng-show="pokemon.data.owner === main.user.name || main.user.isAdmin">
+          <md-tooltip md-direction="left">{{pokemon.parsedNickname}}'s settings</md-tooltip>
+          <i class="material-icons">settings</i>
+        </md-button>
+        <md-menu-content width="4">
+          <md-menu-item>
+            <md-button ng-click="pokemon.edit()" >
+              <div layout="row">
+                <p flex>Edit</p>
+              </div>
+            </md-button>
+          </md-menu-item>
+          <md-menu-item ng-if="!pokemon.isDeleted">
+            <md-button aria-label="Delete Pokémon" ng-click="pokemon.delete()">
+              <div layout="row">
+                <p flex>Delete {{pokemon.parsedNickname}}</p>
+              </div>
+            </md-button>
+          </md-menu-item>
+        </md-menu-content>
+      </md-menu>
+      <md-button class="md-icon-button" aria-label="Upload info" ng-click="pokemon.uploadInfo()">
+        <md-tooltip md-direction="left">Upload info</md-tooltip>
+        <i class="material-icons">info</i>
       </md-button>
     </div>
   </md-toolbar>
@@ -221,18 +238,6 @@
                 <div><strong>3DS Region</strong> <span>{{pokemon.data.consoleRegion}}</span></div>
               </md-card-content>
             </md-card>
-
-            <md-card class="summary" ng-show="pokemon.hasFullData">
-              <md-card-header><span class="card-headline">Upload Info</span></md-card-header>
-              <md-card-content>
-                <!-- add link to owner's profile -->
-                <div><strong>Owner</strong> {{pokemon.data.owner}}</div>
-                <div><strong>Unique in Porybox database?</strong>
-                  <span ng-if="pokemon.data.isUnique">Yes</span>
-                  <span ng-if="!pokemon.data.isUnique">No</span>
-                </div>
-              </md-card-content>
-            </md-card>
           </div>
         </div>
       </md-tab-body>
@@ -371,10 +376,19 @@
       </md-tab-body>
 
     </md-tab>
-    <!-- We'll bring this tab back if/when we implement static PIDs or PS dates
+
     <md-tab label="Analysis">
+      <md-card class="summary" ng-show="pokemon.hasFullData">
+        <md-card-header><span class="card-headline">Porybox clone status</span></md-card-header>
+        <md-card-content>
+          <div><strong>Unique in Porybox database?</strong>
+            <span ng-if="pokemon.data.isUnique">Yes</span>
+            <span ng-if="!pokemon.data.isUnique">No</span>
+          </div>
+        </md-card-content>
+      </md-card>
     </md-tab>
-    -->
+
   </md-tabs>
 </div>
 <div ng-if="pokemon.errorStatusCode" ng-include="'/errors/' + pokemon.errorStatusCode + '.html'"></div>

--- a/client/pokemon/pokemon.ctrl.js
+++ b/client/pokemon/pokemon.ctrl.js
@@ -208,6 +208,26 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
     })).catch(console.error.bind(console));
   };
 
+  this.uploadInfo = (event) => {
+    const useFullScreen = ($mdMedia('sm') || $mdMedia('xs'))  && $scope.customFullscreen;
+    $scope.$watch(function() {
+      return $mdMedia('xs') || $mdMedia('sm');
+    }, function(wantsFullScreen) {
+      $scope.customFullscreen = (wantsFullScreen === true);
+    });
+    return $mdDialog.show({
+      locals: {data: this.data},
+      bindToController: true,
+      controller: ['$mdDialog', editCtrl],
+      controllerAs: 'dialog',
+      templateUrl: 'pokemon/upload-info.view.html',
+      parent: angular.element(document.body),
+      targetEvent: event,
+      clickOutsideToClose: true,
+      fullscreen: useFullScreen
+    });
+  };
+
   this.delete = () => {
     return io.socket.deleteAsync(`/p/${this.id}`).then(() => {
       this.isDeleted = true;

--- a/client/pokemon/upload-info.view.html
+++ b/client/pokemon/upload-info.view.html
@@ -1,0 +1,19 @@
+<!-- add link to owner's profile -->
+<md-dialog aria-label="Upload Info" ng-cloak>
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h2>Upload info</h2>
+      <span flex></span>
+      <md-button class="md-icon-button" ng-click="dialog.cancel()">
+        <i class="material-icons">close</i>
+      </md-button>
+    </div>
+  </md-toolbar>
+  <md-dialog-content class="md-dialog-content">
+    <div><strong>Owner</strong></div>
+    <div>{{dialog.data.owner}}</div>
+    <br/>
+    <div><strong>Notes</strong></div>
+    <div ng-repeat="note in dialog.data.notes">{{note}}</div>
+  </md-dialog-content>
+</md-dialog>


### PR DESCRIPTION
The upload info with notes is probably too much for its own card on the summary, but not enough to take up a whole tab by itself. So after talking with SP and TSAR, I threw it into an Info icon on the toolbar and moved the Delete option into the Settings menu. 

I also brought back the Analysis tab for just the clone status. It's kind of lonely there, but we could add a "more analysis coming soon" message if we wanted to.