### PR TITLE
Allow box fields to be filtered via querystring

### DIFF
--- a/api/controllers/BoxController.js
+++ b/api/controllers/BoxController.js
@@ -29,11 +29,16 @@ module.exports = _.mapValues({
 
   async get (req, res) {
     const params = req.allParams();
+    Validation.requireParams(params, 'id');
     const box = await Box.findOne({
       id: params.id,
       _markedForDeletion: false
     }).populate('contents');
-    return PokemonHandler.getSafeBoxForUser(box, req.user).then(res.ok);
+    const safeBox = await PokemonHandler.getSafeBoxForUser(box, req.user);
+    safeBox.contents = safeBox.contents.map(
+      pkmn => PokemonHandler.pickPokemonFields(pkmn, params.pokemonFields)
+    );
+    return res.ok(safeBox);
   },
 
   mine (req, res) {

--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -102,13 +102,16 @@ module.exports = _.mapValues({
   },
 
   async get (req, res) {
+    const params = req.allParams();
+    Validation.requireParams(params, 'id');
     const pokemon = await Pokemon.findOne({
-      id: req.param('id'),
+      id: params.id,
       _markedForDeletion: false
     }).populate('notes');
-    return PokemonHandler.getSafePokemonForUser(pokemon, req.user, {
+    const safePkmn = await PokemonHandler.getSafePokemonForUser(pokemon, req.user, {
       checkUnique: true
-    }).then(res.ok);
+    });
+    return res.ok(PokemonHandler.pickPokemonFields(safePkmn, params.pokemonFields));
   },
 
   async delete (req, res) {

--- a/api/services/PokemonHandler.js
+++ b/api/services/PokemonHandler.js
@@ -87,3 +87,7 @@ exports.createPokemonFromPk6 = async ({user, visibility, boxId, file}) => {
   parsed.visibility = visibility;
   return parsed;
 };
+
+exports.pickPokemonFields = (pkmn, fieldString) => {
+  return _.isString(fieldString) ? _.pick(pkmn, fieldString.split(',').concat('toJSON')) : pkmn;
+};

--- a/client/box/box-list.view.html
+++ b/client/box/box-list.view.html
@@ -41,7 +41,7 @@
   </md-card>
 
   <div layout="row" layout-xs="column" layout-wrap ng-init="box.fetch()" ng-show="box.hasFullData">
-    <div flex-xs ng-repeat="pokemon in box.data.contents">
+    <div flex-xs ng-repeat="pokemon in box.data.contents track by pokemon.id">
       <pokemon-card data="pokemon"></pokemon-card>
     </div>
   </div>

--- a/client/box/box.ctrl.js
+++ b/client/box/box.ctrl.js
@@ -1,6 +1,34 @@
 const editCtrl = require('./box-edit.ctrl.js');
 const angular = require('angular');
 
+const POKEMON_FIELDS_USED = [
+  'abilityName',
+  'abilityNum',
+  'ballName',
+  'decreasedStat',
+  'esv',
+  'heldItemName',
+  'id',
+  'increasedStat',
+  'isEgg',
+  'isShiny',
+  'ivHp',
+  'ivAtk',
+  'ivDef',
+  'ivSpAtk',
+  'ivSpDef',
+  'ivSpe',
+  'language',
+  'level',
+  'natureName',
+  'nickname',
+  'ot',
+  'otGameId',
+  'speciesName',
+  'tid',
+  'visibility',
+].join(',');
+
 module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog) {
   this.data = this.data || {contents: []};
   this.id = $routeParams.boxid || this.data.id;
@@ -10,7 +38,7 @@ module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog) {
   this.isDeleted = false;
 
   this.fetch = () => {
-    io.socket.getAsync('/b/' + this.id).then(data => {
+    io.socket.getAsync('/b/' + this.id, {pokemonFields: POKEMON_FIELDS_USED}).then(data => {
       Object.assign(this.data, data);
       this.hasFullData = true;
     }).catch(err => {

--- a/client/pokemon/pokemon-card.view.html
+++ b/client/pokemon/pokemon-card.view.html
@@ -1,4 +1,4 @@
-<md-card class="pokemon-card-mini" ng-init="pokemon.parseProps()">
+<md-card class="pokemon-card-mini" ng-init="pokemon.parseBoxViewProps()">
   <a ng-href="#/pokemon/{{pokemon.id}}" class="card-link" ng-attr-title="{{pokemon.data.isEgg ?
   pokemon.parsedNickname + ' (ESV: ' + pokemon.paddedEsv + ')' : pokemon.parsedNickname}}">
     <md-card-header>

--- a/client/pokemon/pokemon.spec.js
+++ b/client/pokemon/pokemon.spec.js
@@ -31,7 +31,7 @@ describe('PokemonCtrl', function() {
         isShiny: false,
         tid: 1, sid: 1, esv: 1, tsv: 1
       }});
-      tested.parseProps();
+      tested.parseAllProps();
       expect(tested.data.nickname).to.equal('pokemondNickname');
       expect(tested.data.owner).to.equal('boxUser');
       expect(tested.data.dexNo).to.equal('pokemonDexNo');
@@ -42,7 +42,7 @@ describe('PokemonCtrl', function() {
     it('are correctly instantiated when not provided at construction', function() {
       $routeParams.pokemonid = 'routeParamId';
       tested = $controller(ctrlTest, deps, {data: {tid: 1, sid: 1, esv: 1, tsv: 1}});
-      tested.parseProps();
+      tested.parseAllProps();
       expect(tested.id).to.equal('routeParamId');
       expect(Object.keys(tested.data).length).to.equal(4);
     });
@@ -50,34 +50,34 @@ describe('PokemonCtrl', function() {
     it("pads a Pokémon's TID correctly", function() {
       const tested1 = $controller(ctrlTest, deps,
         {data: {tid: 12345, sid: 1, esv: 1, tsv: 1}});
-      tested1.parseProps();
+      tested1.parseAllProps();
       expect(tested1.paddedTid).to.equal('12345');
       const tested2 = $controller(ctrlTest, deps,
         {data: {tid: 1234, sid: 1, esv: 1, tsv: 1}});
-      tested2.parseProps();
+      tested2.parseAllProps();
       expect(tested2.paddedTid).to.equal('01234');
       const tested3 = $controller(ctrlTest, deps,
         {data: {tid: 123, sid: 1, esv: 1, tsv: 1}});
-      tested3.parseProps();
+      tested3.parseAllProps();
       expect(tested3.paddedTid).to.equal('00123');
       const tested4 = $controller(ctrlTest, deps,
         {data: {tid: 12, sid: 1, esv: 1, tsv: 1}});
-      tested4.parseProps();
+      tested4.parseAllProps();
       expect(tested4.paddedTid).to.equal('00012');
       const tested5 = $controller(ctrlTest, deps,
         {data: {tid: 1, sid: 1, esv: 1, tsv: 1}});
-      tested5.parseProps();
+      tested5.parseAllProps();
       expect(tested5.paddedTid).to.equal('00001');
       const tested6 = $controller(ctrlTest, deps,
         {data: {tid: 0, sid: 1, esv: 1, tsv: 1}});
-      tested6.parseProps();
+      tested6.parseAllProps();
       expect(tested6.paddedTid).to.equal('00000');
     });
   });
   it('parses unicode characters correctly', function() {
     const dangerbug = $controller(ctrlTest, deps,
       {data: {tid: 12345, sid: 1, esv: 1, tsv: 1, ot: 'Filthy'}});
-    dangerbug.parseProps();
+    dangerbug.parseAllProps();
     expect(dangerbug.parsedOt).to.equal('♥︎Filthy♥︎');
   });
 });

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -139,6 +139,36 @@ describe('BoxController', () => {
       expect(box.contents[1].box).to.not.exist();
       expect(box.contents[2]).to.not.exist();
     });
+    it('allows the properties of the Pokémon in the box to be specified by query', async () => {
+      const res = await agent.get(`/b/${boxId}`).query({pokemonFields: 'speciesName'});
+      expect(res.statusCode).to.equal(200);
+      expect(res.body.id).to.equal(boxId);
+      expect(res.body.contents).to.eql([
+        {speciesName: 'Pelipper'},
+        {speciesName: 'Pelipper'},
+        {speciesName: 'Pelipper'}
+      ]);
+    });
+    it('does not allow private properties of Pokémon to be accessed by the query', async () => {
+      const publicPid = (await agent.get(`/b/${boxId}`)).body.contents[1].pid;
+      const res = await otherAgent.get(`/b/${boxId}`).query({pokemonFields: 'speciesName,pid'});
+      expect(res.statusCode).to.equal(200);
+      expect(res.body.id).to.equal(boxId);
+      expect(res.body.contents).to.eql([
+        {speciesName: 'Pelipper'},
+        {speciesName: 'Pelipper', pid: publicPid}
+      ]);
+    });
+    it('does not allow internal properties of Pokémon to be accessed by the query', async () => {
+      const res = await agent.get(`/b/${boxId}`).query({pokemonFields: 'speciesName,_rawPk6'});
+      expect(res.statusCode).to.equal(200);
+      expect(res.body.id).to.equal(boxId);
+      expect(res.body.contents).to.eql([
+        {speciesName: 'Pelipper'},
+        {speciesName: 'Pelipper'},
+        {speciesName: 'Pelipper'}
+      ]);
+    });
   });
   describe("getting a user's boxes", () => {
     let box1, box2, unlistedBox, otherBox;

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -425,6 +425,27 @@ describe('PokemonController', () => {
       expect(pkmn._markedForDeletion).to.not.exist();
       expect(pkmn._rawPk6).to.not.exist();
     });
+    it('allows a list of fields to be specified as a query parameter', async () => {
+      const res = await agent.get(`/p/${viewableId}`).query({pokemonFields: 'id,visibility,ivHp'});
+      expect(res.statusCode).to.equal(200);
+      expect(res.body).to.eql({id: viewableId, visibility: 'viewable', ivHp: 31});
+    });
+    it('does not allow private fields to be sent even if specified in the query', async () => {
+      const res = await otherAgent.get(`/p/${viewableId}`).query({pokemonFields: 'id,pid'});
+      expect(res.statusCode).to.equal(200);
+      expect(res.body).to.eql({id: viewableId});
+      expect(res.body.pid).not.to.exist();
+    });
+    it('allows private fields to be sent to the owner if specified in the query', async () => {
+      const res = await agent.get(`/p/${viewableId}`).query({pokemonFields: 'pid'});
+      expect(res.statusCode).to.equal(200);
+      expect(Object.keys(res.body)).to.eql(['pid']);
+    });
+    it('does not leak internal properties of a pokemon if specified in the query', async () => {
+      const res = await agent.get(`/p/${viewableId}`).query({pokemonFields: '_rawPk6'});
+      expect(res.statusCode).to.equal(200);
+      expect(res.body).to.eql({});
+    });
   });
 
   describe('deleting a pokemon', () => {


### PR DESCRIPTION
Relates to #247

This allows a `pokemonFields` querystring parameter to be used for fetching boxes and Pokémon. It should be useful to reduce the server's response size for large boxes, since we don't actually need all the properties of all the box contents.

e.g.

* `GET /b/abcdef?pokemonFields=id,dexNo,speciesName`
* `GET /p/uvwxyz?pokemonFields=id,dexNo,speciesName`

This also modifies the client to only fetch the fields that are needed.