### PR TITLE
Don't leak model values such as `createdAt` to clients

### DIFF
--- a/api/models/Box.js
+++ b/api/models/Box.js
@@ -72,7 +72,9 @@ module.exports =  {
     Conveniently, this means that the internal properties are never sent to the client.
     (Not to be confused with the omitPrivateContents function, which removes *confidential* data.) */
     toJSON () {
-      return _.omit(this, (value, key) => key.startsWith('_'));
+      return _.omit(this, (value, key) => {
+        return key.startsWith('_') || ['updatedAt'].includes(key);
+      });
     }
   },
   beforeCreate (box, next) {

--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -163,7 +163,9 @@ const attributes = {
     /* Omit internal properties (i.e. properties that start with '_') when converting to JSON.
     Conveniently, this means that the internal properties are never sent to the client.
     (Not to be confused with the omitPrivateData function, which removes *confidential* data.) */
-    return _.omit(this, (value, key) => key.startsWith('_'));
+    return _.omit(this, (value, key) => {
+      return key.startsWith('_') || ['updatedAt'].includes(key);
+    });
   },
   assignParsedNames () {
     return pk6parse.assignReadableNames(this);

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -78,7 +78,9 @@ module.exports =  {
       await DeletedUser.create({name: this.name});
     },
     toJSON () {
-      return _.omit(this, (value, key) => key.startsWith('_'));
+      return _.omit(this, (value, key) => {
+        return key.startsWith('_') || ['updatedAt', 'passports'].includes(key);
+      });
     }
   }
 };

--- a/api/models/UserPreferences.js
+++ b/api/models/UserPreferences.js
@@ -1,3 +1,8 @@
 const attributes = _.clone(Constants.CHANGEABLE_PREFERENCES);
 attributes.user = {model: 'User', unique: true, primaryKey: true};
+attributes.toJSON = function () {
+  return _.omit(this, (value, key) => {
+    return key.startsWith('_') || ['createdAt', 'updatedAt', 'id'].includes(key);
+  });
+};
 module.exports = {schema: true, attributes};

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -94,6 +94,8 @@ describe('BoxController', () => {
       expect(box.contents[2].pid).to.exist();
       expect(box.contents[2].speciesName).to.exist();
       expect(box.contents[2].box).to.equal(box.id);
+      expect(box.createdAt).to.be.a('string');
+      expect(box.updatedAt).to.not.exist();
     });
     it('allows third parties to view a box, filtering contents by pokemon visibility', async () => {
       const box = (await otherAgent.get(`/b/${boxId}`)).body;

--- a/test/controller/user.js
+++ b/test/controller/user.js
@@ -42,6 +42,12 @@ describe('UserController', () => {
       expect(res.body.friendCodes).to.be.an.instanceof(Array);
       expect(res.body.inGameNames).to.be.an.instanceof(Array);
       expect(res.body.trainerShinyValues).to.be.an.instanceof(Array);
+      expect(res.body.createdAt).to.be.a('string');
+      expect(res.body.updatedAt).not.to.exist();
+      expect(res.body.passports).not.to.exist();
+      expect(res.body.preferences.createdAt).to.not.exist();
+      expect(res.body.preferences.updatedAt).to.not.exist();
+      expect(res.body.preferences.id).to.not.exist();
     });
     it("omits private information when a user gets someone else's profile", async () => {
       const res = await agent.get('/user/IM_AN_ADMIN_FEAR_ME');
@@ -53,6 +59,9 @@ describe('UserController', () => {
       expect(res.body.friendCodes).to.exist();
       expect(res.body.inGameNames).to.exist();
       expect(res.body.trainerShinyValues).exist();
+      expect(res.body.createdAt).to.be.a('string');
+      expect(res.body.updatedAt).not.to.exist();
+      expect(res.body.passports).not.to.exist();
     });
     it("returns full information when an admin gets someone else's profile", async () => {
       const res = await adminAgent.get('/user/usertester');


### PR DESCRIPTION
This poses a small privacy concern, e.g. we don't want other users to know when a user's profile was last updated.