### PR TITLE
Improve the upload toast

### DIFF
--- a/client/add/add.module.js
+++ b/client/add/add.module.js
@@ -16,6 +16,6 @@ ng.module('porybox.add', ['porybox.box', 'porybox.pokemon', 'ngMessages', 'ngFil
       selected: '='
     },
     templateUrl: 'add/add.view.html',
-    controller: ['$scope', 'io', '$mdDialog', '$mdMedia', '$mdToast', controller],
+    controller: ['$scope', '$location', 'io', '$mdDialog', '$mdMedia', '$mdToast', controller],
     controllerAs: 'add'
   });

--- a/client/add/pokemon.view.html
+++ b/client/add/pokemon.view.html
@@ -36,7 +36,7 @@
 
         Or upload a file:
         <input type="file" ngf-select ng-model="pkmDialog.file" name="file"
-             accept=".pk6" ngf-max-size="2MB" required ng-change="pkmDialog.addFile()"
+             accept=".pk6" ngf-max-size="2MB" ng-change="pkmDialog.addFile()"
              ngf-model-invalid="errorFile">
         <md-divider></md-divider>
         <div>
@@ -48,7 +48,7 @@
       <md-button ng-click="pkmDialog.cancel()">
        Cancel
       </md-button>
-      <md-button ng-click="pkmDialog.answer()" ng-disabled="!pkmDialog.canAdd()" type="submit">
+      <md-button ng-click="pkmDialog.answer()" ng-disabled="!pkmDialog.canAdd() || !pkmDialog.lines.length" type="submit">
         Upload
       </md-button>
     </md-dialog-actions>


### PR DESCRIPTION
* Disables the "upload" button if no files are selected
* Adds a "View" button to the toast for when exactly one thing has been uploaded successfully, linking to the uploaded thing. The button does not display if multiple things were uploaded successfully.
* Display different messages depending on how many things were uploaded:
  * (if no errors): "25 Pokémon uploaded successfully"
  * (if some errors and some success): "10 Pokémon uploaded successfully (15 failed)"
  * (if all errors): "Upload failed, no Pokémon uploaded"