### PR TITLE
Fix an issue where the box updatedAt field wasn't getting changed

### DIFF
--- a/api/services/BoxOrdering.js
+++ b/api/services/BoxOrdering.js
@@ -12,7 +12,10 @@ module.exports = {
   getOrderedBoxList: _.partial(_getOrderedItemList, _, 'boxes', '_orderedBoxIds'),
   addPkmnIdsToBox (boxId, pkmnIds, position) {
     return Promise.fromCallback(Box.native.bind(Box)).then(collection => {
-      const query = {$push: {_orderedIds: {$each: pkmnIds}}};
+      const query = {
+        $push: {_orderedIds: {$each: pkmnIds}},
+        $set: {updatedAt: new Date().toISOString()}
+      };
       if (_.isNumber(position)) {
         query.$push._orderedIds.$position = position;
       }
@@ -22,13 +25,19 @@ module.exports = {
 
   removePkmnIdFromBox (boxId, pkmnId) {
     return Promise.fromCallback(Box.native.bind(Box)).then(collection => {
-      return collection.update({_id: boxId}, {$pull: {_orderedIds: pkmnId}});
+      return collection.update({_id: boxId}, {
+        $pull: {_orderedIds: pkmnId},
+        $set: {updatedAt: new Date().toISOString()}
+      });
     });
   },
 
   addBoxIdsToUser (username, boxIds, position) {
     return Promise.fromCallback(User.native.bind(User)).then(collection => {
-      const query = {$push: {_orderedBoxIds: {$each: boxIds}}};
+      const query = {
+        $push: {_orderedBoxIds: {$each: boxIds}},
+        $set: {updatedAt: new Date().toISOString()}
+      };
       if (_.isNumber(position)) {
         query.$push._orderedBoxIds.$position = position;
       }
@@ -38,7 +47,10 @@ module.exports = {
 
   removeBoxIdFromUser (username, boxId) {
     return Promise.fromCallback(User.native.bind(User)).then(collection => {
-      return collection.update({_id: username}, {$pull: {_orderedBoxIds: boxId}});
+      return collection.update({_id: username}, {
+        $pull: {_orderedBoxIds: boxId},
+        $set: {updatedAt: new Date().toISOString()}
+      });
     });
   }
 };

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -688,6 +688,7 @@ describe('PokemonController', () => {
       expect(_.map(updatedBox1.contents, 'id')).to.eql([pkmn2.id, pkmn3.id]);
       const updatedBox2 = (await agent.get(`/b/${box2.id}`)).body;
       expect(_.map(updatedBox2.contents, 'id')).to.eql([pkmn4.id, pkmn5.id, pkmn6.id, pkmn.id]);
+      expect(+new Date(updatedBox2.updatedAt)).to.be.above(+new Date(box2.updatedAt));
     });
     it('allows an index to be specified for the pokemon within the new box', async () => {
       const res = await agent.post(`/p/${pkmn2.id}/move`).send({box: box2.id, index: 1});


### PR DESCRIPTION
The `updatedAt` property is a waterline feature, so it wasn't getting used in native queries.