### PR TITLE
Don't log errors when users close windows

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -103,10 +103,12 @@ porybox.service('io', function () {
 
 porybox.service('errorHandler', ['$mdToast', function ($mdToast) {
   return reason => {
-    console.error(reason);
-    $mdToast.show(
-      $mdToast.simple().textContent('An unexpected error occured.').position('bottom right')
-    );
+    if (reason) {
+      console.error(reason);
+      $mdToast.show(
+        $mdToast.simple().textContent('An unexpected error occured.').position('bottom right')
+      );
+    }
   };
 }]);
 


### PR DESCRIPTION
fixes #299 

I think the issue is that the modal window promise ends up rejecting if the user cancels the window.