### PR TITLE
Ensure that templates aren't loaded from cache after bumping the version

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -11,6 +11,7 @@ const Promise = require('bluebird');
 Promise.config({warnings: false});
 
 const CSRF_TOKEN = document.getElementById('csrf-token').innerHTML;
+const APP_VERSION = document.getElementById('app-version').innerHTML;
 
 // Import modules
 require('./login/login.module.js');
@@ -75,8 +76,19 @@ porybox.config(['$mdThemingProvider','$routeProvider',function(
   $routeProvider.otherwise({ redirectTo: '/' });
 }]);
 
+// Add a ?v=1.0.0 (e.g.) query to all requests for templates
+// This avoids browser cache issues when the version number is bumped
+porybox.factory('porybox.versionQuery', ['$templateCache', $templateCache => ({request (config) {
+  if (config.url.endsWith('.html') && !$templateCache.get(config.url)) {
+    config.params = config.params || {};
+    config.params.v = APP_VERSION;
+  }
+  return config;
+}})]);
+
 porybox.config(['$httpProvider', function ($httpProvider) {
   $httpProvider.defaults.headers.common['x-csrf-token'] = CSRF_TOKEN;
+  $httpProvider.interceptors.push('porybox.versionQuery');
 }]);
 
 porybox.service('io', function () {

--- a/client/layout.ejs
+++ b/client/layout.ejs
@@ -39,6 +39,7 @@
       </div>
     </div>
     <div id="csrf-token"><%= typeof _csrf !== undefined ? _csrf : '' %></div>
+    <div id="app-version"><%= VERSION %></div>
     <script src="<%=
       (sails.config.environment === 'development' ? '/bundle.js' : '/bundle.min.js') + '?v=' + VERSION
     %>"></script>

--- a/client/styles/importer.less
+++ b/client/styles/importer.less
@@ -455,9 +455,9 @@ span[class^='gender-'] {
 }
 
 /*******************************
- * Csrf token (hidden div)
+ * Hidden divs
  *******************************/
-#csrf-token {
+#csrf-token, #app-version {
   display: none;
 }
 


### PR DESCRIPTION
This adds a `?v=VERSION` querystring to all requests for templates, which should prevent them from getting loaded from the browser's cache after we update porybox's version number.