### PR TITLE
Upgrade pk6parse to v0.10.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "passport": "^0.3.2",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
-    "pk6parse": "^0.10.12",
+    "pk6parse": "^0.10.13",
     "rc": "1.1.6",
     "sails": "0.12.3",
     "sails-disk": "0.10.10",


### PR DESCRIPTION
[Changelog](/porygonco/pk6parse/blob/master/CHANGELOG.md#v01013-2016-07-10)

> * Fixed an issue where Magikarp's data file was incorrectly formatted
* Fixed an issue where certain memories would cause parsing failures
* Fixed an issue where item data for Latiasite/Latiosite was missing
* Fixed an issue where item data for the ORAS "Bike" item was missing

Fixes #326