### PR TITLE
Use `ng-non-bindable` to escape angular expressions in ejs data

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -12,6 +12,7 @@ Promise.config({warnings: false});
 
 const CSRF_TOKEN = document.getElementById('csrf-token').innerHTML;
 const APP_VERSION = document.getElementById('app-version').innerHTML;
+const userData = JSON.parse(document.getElementById('user-data').innerHTML);
 
 // Import modules
 require('./login/login.module.js');
@@ -42,21 +43,16 @@ const porybox = ng.module('porybox', [
 porybox.controller('MainCtrl', function () {
   this.boxes = [];
   this.selected = {};
-  this.init = function ({boxes, user, prefs, selectedBox}) {
-    this.boxes = boxes;
-    this.user = user;
-    // TODO: Figure out a better way to do this
-    const LOGGED_IN_ONLY_ROUTES = ['#/prefs', '', '#/'];
-    const LOGGED_OUT_ONLY_ROUTES = ['#/login'];
-    if (!this.user && location.pathname === '/' && LOGGED_IN_ONLY_ROUTES.includes(location.hash)) {
-      location.hash = 'home';
-    }
-    if (this.user && location.pathname === '/' && LOGGED_OUT_ONLY_ROUTES.includes(location.hash)) {
-      location.hash = '/';
-    }
-    this.prefs = prefs;
-    this.selected.box = selectedBox;
-  };
+  Object.assign(this, userData);
+  // TODO: Figure out a better way to do this
+  const LOGGED_IN_ONLY_ROUTES = ['#/prefs', '', '#/'];
+  const LOGGED_OUT_ONLY_ROUTES = ['#/login'];
+  if (!this.user && location.pathname === '/' && LOGGED_IN_ONLY_ROUTES.includes(location.hash)) {
+    location.hash = 'home';
+  }
+  if (this.user && location.pathname === '/' && LOGGED_OUT_ONLY_ROUTES.includes(location.hash)) {
+    location.hash = '/';
+  }
 });
 
 porybox.config(['$mdThemingProvider','$routeProvider',function(

--- a/client/layout.ejs
+++ b/client/layout.ejs
@@ -22,12 +22,7 @@
     </script>
   </head>
 
-  <body flex layout="column" ng-controller="MainCtrl as main" ng-cloak layout-fill
-    ng-init="main.init({
-      boxes: <%=(typeof boxes !== 'undefined' ? JSON.stringify(boxes) : '[]')%>,
-      user: <%=(typeof user !== 'undefined' ? JSON.stringify(user) : 'null')%>,
-      prefs: <%=(typeof prefs !== 'undefined' ? JSON.stringify(prefs) : '{}')%>
-    })">
+  <body flex layout="column" ng-controller="MainCtrl as main" ng-cloak layout-fill>
     <div id="scroll-container">
       <%- include header.ejs %>
       <div flex layout="column">
@@ -40,6 +35,13 @@
     </div>
     <div id="csrf-token"><%= typeof _csrf !== undefined ? _csrf : '' %></div>
     <div id="app-version"><%= VERSION %></div>
+    <div id="user-data" ng-non-bindable>
+      <%= JSON.stringify({
+        boxes: typeof boxes !== 'undefined' ? boxes : [],
+        user: typeof user !== 'undefined' ? user : null,
+        prefs: typeof prefs !== 'undefined' ? prefs : {}
+      }) %>
+    </div>
     <script src="<%=
       (sails.config.environment === 'development' ? '/bundle.js' : '/bundle.min.js') + '?v=' + VERSION
     %>"></script>

--- a/client/styles/importer.less
+++ b/client/styles/importer.less
@@ -457,7 +457,7 @@ span[class^='gender-'] {
 /*******************************
  * Hidden divs
  *******************************/
-#csrf-token, #app-version {
+#csrf-token, #app-version, #user-data {
   display: none;
 }
 


### PR DESCRIPTION
This fixes a bug where weird angular errors that would occur if boxes had certain names.

The bug did not allow full XSS, since angular sandboxes expressions to prevent that. But we should still escape the expressions anyway.