### PR TITLE
Make API endpoints more RESTful

### DIFF
--- a/client/add/add.ctrl.js
+++ b/client/add/add.ctrl.js
@@ -50,7 +50,7 @@ module.exports = function($scope, $location, io, $mdDialog, $mdMedia, $mdToast, 
     })).map(Promise.props)
       .map(result => ({data: result.data, box: result.box, visibility: result.visibility}))
       .then(files => chunk(files, maxMultiUploadSize))
-      .mapSeries(files => io.socket.postAsync('/pk6/multi', {files}))
+      .mapSeries(files => io.socket.postAsync('/pokemon/multi', {files}))
       .reduce((acc, nextGroup) => acc.concat(nextGroup), [])
       .tap(lines => {
         const successfulUploads = lines.filter(line => line.success);

--- a/client/box/box.ctrl.js
+++ b/client/box/box.ctrl.js
@@ -48,7 +48,7 @@ module.exports = function(
   this.currentPageNum = +$routeParams.pageNum || this.data.pageNum || 1;
 
   this.fetch = () => {
-    return io.socket.getAsync('/b/' + this.id, {
+    return io.socket.getAsync(`/box/${this.id}`, {
       pokemonFields: POKEMON_FIELDS_USED,
       page: this.currentPageNum
     }).then(data => {
@@ -98,7 +98,7 @@ module.exports = function(
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.postAsync('/b/' + this.id + '/edit', editedData).then(() => {
+      return io.socket.postAsync(`/box/${this.id}`, editedData).then(() => {
         Object.assign(this.data, editedData);
         if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes) {
           const thisBox = $scope.$parent.main.boxes.find(box => box.id === this.id);
@@ -110,7 +110,7 @@ module.exports = function(
   };
 
   this.delete = () => {
-    io.socket.deleteAsync('/b/' + this.id).then(() => {
+    io.socket.deleteAsync(`/box/${this.id}`).then(() => {
       this.isDeleted = true;
       $scope.$apply();
       if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes) {
@@ -125,7 +125,7 @@ module.exports = function(
   };
 
   this.undelete = () => {
-    io.socket.postAsync('/b/' + this.id + '/undelete').then(() => {
+    io.socket.postAsync(`/box/${this.id}/undelete`).then(() => {
       this.isDeleted = false;
       $scope.$apply();
       if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes
@@ -137,7 +137,7 @@ module.exports = function(
   };
   this.movePkmn = (pkmn, localIndex) => {
     const absoluteIndex = boxPageSize * (this.data.pageNum - 1) + localIndex;
-    return io.socket.postAsync(`/p/${pkmn.id}/move`,{box: this.id, index: absoluteIndex})
+    return io.socket.postAsync(`/pokemon/${pkmn.id}/move`,{box: this.id, index: absoluteIndex})
       .catch(errorHandler);
   };
 };

--- a/client/pokemon/pokemon-full.view.html
+++ b/client/pokemon/pokemon-full.view.html
@@ -17,7 +17,7 @@
         </span>
       </div>
       <span flex></span>
-      <a ng-href="/p/{{pokemon.id}}/download">
+      <a ng-href="/pokemon/{{pokemon.id}}/pk6">
         <md-button class="md-icon-button" aria-label="Download .pk6 file" ng-show="pokemon.data.owner === main.user.name || main.user.isAdmin || pokemon.data.visibility === 'public'">
           <md-tooltip md-direction="left">Download .pk6 file</md-tooltip>
           <i class="material-icons">file_download</i>

--- a/client/pokemon/pokemon.ctrl.js
+++ b/client/pokemon/pokemon.ctrl.js
@@ -180,7 +180,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   };
 
   this.fetch = () => {
-    return io.socket.getAsync(`/p/${this.id}`).then(data => {
+    return io.socket.getAsync(`/pokemon/${this.id}`).then(data => {
       Object.assign(this.data, data);
     }).then(this.parseAllProps).catch(err => {
       this.errorStatusCode = err.statusCode;
@@ -206,7 +206,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.postAsync(`/p/${this.id}/edit`, editedData).then(() => {
+      return io.socket.postAsync(`/pokemon/${this.id}`, editedData).then(() => {
         Object.assign(this.data, editedData);
         $mdToast.show(
           $mdToast.simple()
@@ -239,7 +239,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   };
 
   this.delete = () => {
-    return io.socket.deleteAsync(`/p/${this.id}`).then(() => {
+    return io.socket.deleteAsync(`/pokemon/${this.id}`).then(() => {
       this.isDeleted = true;
     }).then(() => {
       const toast = $mdToast.simple()
@@ -258,7 +258,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   };
 
   this.undelete = () => {
-    return io.socket.postAsync(`/p/${this.id}/undelete`).then(() => {
+    return io.socket.postAsync(`/pokemon/${this.id}/undelete`).then(() => {
       this.isDeleted = false;
     }).then(() => {
       $mdToast.show(
@@ -273,7 +273,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   ** index (optional): the index where this pokemon should be inserted in the new box.
   ** (Defaults to the last spot in the box.) */
   this.move = ({box, index}) => {
-    return io.socket.postAsync(`/p/${this.id}/move`, {box, index}).then(() => {
+    return io.socket.postAsync(`/pokemon/${this.id}/move`, {box, index}).then(() => {
       $scope.$apply();
     }).catch(errorHandler);
   };

--- a/config/routes.js
+++ b/config/routes.js
@@ -37,11 +37,11 @@ module.exports.routes = {
   // Boxes
 
   'post /box': 'BoxController.add',
-  'get /b/:id': 'BoxController.get',
-  'get /boxes/mine': 'BoxController.mine',
-  'delete /b/:id': 'BoxController.delete',
-  'post /b/:id/undelete': 'BoxController.undelete',
-  'post /b/:id/edit': 'BoxController.edit',
+  'get /box/:id': 'BoxController.get',
+  'get /me/boxes': 'BoxController.mine',
+  'delete /box/:id': 'BoxController.delete',
+  'post /box/:id/undelete': 'BoxController.undelete',
+  'post /box/:id': 'BoxController.edit',
 
   // Authentication
 
@@ -56,26 +56,26 @@ module.exports.routes = {
 
   // Pokemon
 
-  'post /uploadpk6': 'PokemonController.uploadpk6',
-  'post /pk6/multi': 'PokemonController.uploadMultiPk6',
+  'post /pokemon': 'PokemonController.uploadpk6',
+  'post /pokemon/multi': 'PokemonController.uploadMultiPk6',
 
-  'get /p/:id': 'PokemonController.get',
-  'get /p/:id/download': 'PokemonController.download',
-  'delete /p/:id': 'PokemonController.delete',
-  'post /p/:id/undelete': 'PokemonController.undelete',
-  'post /p/:id/move': 'PokemonController.move',
-  'post /p/:id/edit': 'PokemonController.edit',
+  'get /pokemon/:id': 'PokemonController.get',
+  'get /pokemon/:id/pk6': 'PokemonController.download',
+  'delete /pokemon/:id': 'PokemonController.delete',
+  'post /pokemon/:id/undelete': 'PokemonController.undelete',
+  'post /pokemon/:id/move': 'PokemonController.move',
+  'post /pokemon/:id': 'PokemonController.edit',
 
   // Users
   'get /user/:name': 'UserController.get',
   'get /user/:name/boxes': 'UserController.boxes',
   'get /me': 'UserController.me',
-  'get /preferences': 'UserController.getPreferences',
-  'post /preferences/edit': 'UserController.editPreferences',
+  'get /me/preferences': 'UserController.getPreferences',
+  'post /me/preferences': 'UserController.editPreferences',
   'post /me': 'UserController.editAccountInfo',
   'post /user/:name/grantAdminStatus': 'UserController.grantAdminStatus',
   'post /user/:name/revokeAdminStatus': 'UserController.revokeAdminStatus',
-  'post /deleteAccount': 'UserController.deleteAccount',
+  'delete /me': 'UserController.deleteAccount',
   'post /changePassword': 'UserController.changePassword',
   'get /checkUsernameAvailable': 'UserController.checkUsernameAvailable'
 };

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -24,7 +24,7 @@ describe('AuthController', function() {
         email: 'testuser1@gmail.com'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get('/preferences');
+      const res2 = await agent.get('/me/preferences');
       expect(res2.statusCode).to.equal(200);
     });
 
@@ -126,7 +126,7 @@ describe('AuthController', function() {
         email: 'invalid3@porybox.com'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await otherAgent.post('/deleteAccount').send({password: 'blahblahblah'});
+      const res2 = await otherAgent.del('/me').send({password: 'blahblahblah'});
       expect(res2.statusCode).to.equal(200);
       const res3 = await invalidAgent.post('/auth/local/register').send({
         name: 'CLAIMEDUSERNAME2',
@@ -261,7 +261,7 @@ describe('AuthController', function() {
       expect(res.statusCode).to.equal(200);
 
       // Do a request to make sure it doesn't work
-      const res2 = await logoutAgent.get('/boxes/mine');
+      const res2 = await logoutAgent.get('/me/boxes');
       expect(res2.statusCode).to.equal(403);
     });
   });


### PR DESCRIPTION
fixes #194

This PR updates the server's API endpoints to be more RESTful. It also updates the client and the tests to match these endpoints.

I'm open to any other suggestions anyone might have about making endpoints more RESTful, but I thought we should change this sooner rather than later so that people can start relying on our API.