### PR TITLE
Make API endpoints more RESTful

### DIFF
--- a/client/add/add.ctrl.js
+++ b/client/add/add.ctrl.js
@@ -27,7 +27,7 @@ module.exports = function($scope, $location, io, $mdDialog, $mdMedia, $mdToast, 
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     })
-    .then((boxInfo) => io.socket.postAsync('/box', boxInfo)))
+    .then((boxInfo) => io.socket.postAsync('/api/v1/box', boxInfo)))
     .then(res => $scope.$apply(this.boxes.push(res)))
     .catch(errorHandler);
   };
@@ -50,7 +50,7 @@ module.exports = function($scope, $location, io, $mdDialog, $mdMedia, $mdToast, 
     })).map(Promise.props)
       .map(result => ({data: result.data, box: result.box, visibility: result.visibility}))
       .then(files => chunk(files, maxMultiUploadSize))
-      .mapSeries(files => io.socket.postAsync('/pk6/multi', {files}))
+      .mapSeries(files => io.socket.postAsync('/api/v1/pokemon/multi', {files}))
       .reduce((acc, nextGroup) => acc.concat(nextGroup), [])
       .tap(lines => {
         const successfulUploads = lines.filter(line => line.success);

--- a/client/app.js
+++ b/client/app.js
@@ -92,8 +92,9 @@ porybox.service('io', function () {
   const socket = require('socket.io-client');
   const io = require('sails.io.js')(socket);
   io.sails.headers = {'x-csrf-token': CSRF_TOKEN};
+  io.socket.patch = (url, data, cb) => io.socket.request({method: 'PATCH', url, data}, cb);
   // create versions of the io.socket functions that return Promises.
-  // e.g. io.socket.getAsync('/foo').then(handleResponse).catch(handleErrors)
+  // e.g. io.socket.getAsync('/api/v1/foo').then(handleResponse).catch(handleErrors)
   Promise.promisifyAll(io.socket, {
     promisifier (fn) {
       return function (...args) {

--- a/client/box/box.ctrl.js
+++ b/client/box/box.ctrl.js
@@ -48,7 +48,7 @@ module.exports = function(
   this.currentPageNum = +$routeParams.pageNum || this.data.pageNum || 1;
 
   this.fetch = () => {
-    return io.socket.getAsync('/b/' + this.id, {
+    return io.socket.getAsync(`/api/v1/box/${this.id}`, {
       pokemonFields: POKEMON_FIELDS_USED,
       page: this.currentPageNum
     }).then(data => {
@@ -98,7 +98,7 @@ module.exports = function(
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.postAsync('/b/' + this.id + '/edit', editedData).then(() => {
+      return io.socket.postAsync(`/api/v1/box/${this.id}`, editedData).then(() => {
         Object.assign(this.data, editedData);
         if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes) {
           const thisBox = $scope.$parent.main.boxes.find(box => box.id === this.id);
@@ -110,7 +110,7 @@ module.exports = function(
   };
 
   this.delete = () => {
-    io.socket.deleteAsync('/b/' + this.id).then(() => {
+    io.socket.deleteAsync(`/box/${this.id}`).then(() => {
       this.isDeleted = true;
       $scope.$apply();
       if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes) {
@@ -125,7 +125,7 @@ module.exports = function(
   };
 
   this.undelete = () => {
-    io.socket.postAsync('/b/' + this.id + '/undelete').then(() => {
+    io.socket.postAsync(`/api/v1/box/${this.id}/undelete`).then(() => {
       this.isDeleted = false;
       $scope.$apply();
       if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes
@@ -137,7 +137,9 @@ module.exports = function(
   };
   this.movePkmn = (pkmn, localIndex) => {
     const absoluteIndex = boxPageSize * (this.data.pageNum - 1) + localIndex;
-    return io.socket.postAsync(`/p/${pkmn.id}/move`,{box: this.id, index: absoluteIndex})
-      .catch(errorHandler);
+    return io.socket.postAsync(
+      `/api/v1/pokemon/${pkmn.id}/move`,
+      {box: this.id, index: absoluteIndex}
+    ).catch(errorHandler);
   };
 };

--- a/client/login/login.ctrl.js
+++ b/client/login/login.ctrl.js
@@ -16,7 +16,7 @@ module.exports = function ($scope, $http) {
   this.register = () => {
     return $http({
       method: 'POST',
-      url: '/auth/local/register',
+      url: '/api/v1/auth/local/register',
       data: {
         name: $scope.registerName,
         password: $scope.registerPassword,
@@ -36,7 +36,7 @@ module.exports = function ($scope, $http) {
   this.login = () => {
     return $http({
       method: 'POST',
-      url: '/auth/local',
+      url: '/api/v1/auth/local',
       data: {
         name: $scope.loginName,
         password: $scope.loginPassword

--- a/client/pokemon/pokemon-full.view.html
+++ b/client/pokemon/pokemon-full.view.html
@@ -17,7 +17,7 @@
         </span>
       </div>
       <span flex></span>
-      <a ng-href="/p/{{pokemon.id}}/download">
+      <a ng-href="/pokemon/{{pokemon.id}}/pk6">
         <md-button class="md-icon-button" aria-label="Download .pk6 file" ng-show="pokemon.data.owner === main.user.name || main.user.isAdmin || pokemon.data.visibility === 'public'">
           <md-tooltip md-direction="left">Download .pk6 file</md-tooltip>
           <i class="material-icons">file_download</i>

--- a/client/pokemon/pokemon.ctrl.js
+++ b/client/pokemon/pokemon.ctrl.js
@@ -31,16 +31,16 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
       ? this.data.heldItemName.replace(' ', '-').replace('é', 'e').replace('\'', '').toLowerCase()
       : null);
 
-    const shinyStringPart = this.data.isShiny ? 'shiny' : 'regular';
-    const genderDiffPart = this.data.gender === 'F' && genderDifferences.has(this.data.dexNo)
+    const shinyString = this.data.isShiny ? 'shiny' : 'regular';
+    const genderDiff = this.data.gender === 'F' && genderDifferences.has(this.data.dexNo)
       ? '-f'
       : '';
     const formSuffix = this.data.formId > 0 && [25, 664, 665].indexOf(this.data.dexNo) === -1
       ? '-' + this.data.formId
       : '';
 
-    this.spriteUrl = `pokemon/${shinyStringPart}/${this.data.dexNo}${formSuffix}${genderDiffPart}`;
-    this.spriteClass = `spr-${shinyStringPart} spr-box-${this.data.dexNo}${formSuffix}${genderDiffPart}`;
+    this.spriteUrl = `pokemon/${shinyString}/${this.data.dexNo}${formSuffix}${genderDiff}`;
+    this.spriteClass = `spr-${shinyString} spr-box-${this.data.dexNo}${formSuffix}${genderDiff}`;
 
     this.isKB = this.data.otGameId >= 24 && this.data.otGameId <= 29;
     this.hasHA = this.data.abilityNum === 4;
@@ -180,7 +180,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   };
 
   this.fetch = () => {
-    return io.socket.getAsync(`/p/${this.id}`).then(data => {
+    return io.socket.getAsync(`/api/v1/pokemon/${this.id}`).then(data => {
       Object.assign(this.data, data);
     }).then(this.parseAllProps).catch(err => {
       this.errorStatusCode = err.statusCode;
@@ -206,7 +206,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.postAsync(`/p/${this.id}/edit`, editedData).then(() => {
+      return io.socket.patchAsync(`/api/v1/pokemon/${this.id}`, editedData).then(() => {
         Object.assign(this.data, editedData);
         $mdToast.show(
           $mdToast.simple()
@@ -239,7 +239,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   };
 
   this.delete = () => {
-    return io.socket.deleteAsync(`/p/${this.id}`).then(() => {
+    return io.socket.deleteAsync(`/pokemon/${this.id}`).then(() => {
       this.isDeleted = true;
     }).then(() => {
       const toast = $mdToast.simple()
@@ -258,7 +258,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   };
 
   this.undelete = () => {
-    return io.socket.postAsync(`/p/${this.id}/undelete`).then(() => {
+    return io.socket.postAsync(`/api/v1/pokemon/${this.id}/undelete`).then(() => {
       this.isDeleted = false;
     }).then(() => {
       $mdToast.show(
@@ -273,7 +273,7 @@ module.exports = function($routeParams, $scope, io, $mdMedia, $mdDialog, $mdToas
   ** index (optional): the index where this pokemon should be inserted in the new box.
   ** (Defaults to the last spot in the box.) */
   this.move = ({box, index}) => {
-    return io.socket.postAsync(`/p/${this.id}/move`, {box, index}).then(() => {
+    return io.socket.postAsync(`/api/v1/pokemon/${this.id}/move`, {box, index}).then(() => {
       $scope.$apply();
     }).catch(errorHandler);
   };

--- a/client/prefs/prefs.ctrl.js
+++ b/client/prefs/prefs.ctrl.js
@@ -17,14 +17,15 @@ module.exports = function (io, $mdToast, errorHandler) {
           .textContent('Error: Passwords may not be longer than 72 characters.')
       );
     }
-    return io.socket.postAsync('/changePassword', {
+    return io.socket.postAsync('/api/v1/changePassword', {
       oldPassword: this.oldPassword,
       newPassword: this.newPassword1
     }).then(() => {
       this.oldPassword = '';
       this.newPassword1 = '';
       this.newPassword2 = '';
-      return $mdToast.simple().position('bottom right').textContent('Password updated successfully');
+      return $mdToast.simple()
+        .position('bottom right').textContent('Password updated successfully');
     }).catch({statusCode: 403, body: 'Incorrect password'}, () => {
       return $mdToast.simple().position('bottom right').textContent('Incorrect password');
     }).then(toast => {

--- a/client/profile/profile.ctrl.js
+++ b/client/profile/profile.ctrl.js
@@ -9,7 +9,7 @@ module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog, errorHa
   this.fetch = () => Promise.all([this.fetchInfo, this.fetchBoxes]);
 
   this.fetchInfo = () => {
-    return io.socket.getAsync(`/user/${this.data.name}`).then(res => {
+    return io.socket.getAsync(`/api/v1/user/${this.data.name}`).then(res => {
       Object.assign(this.data, res);
     }).catch(err => {
       this.errorStatusCode = err.statusCode;
@@ -17,7 +17,7 @@ module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog, errorHa
   };
 
   this.fetchBoxes = () => {
-    return io.socket.getAsync(`/user/${this.data.name}/boxes`).then(res => {
+    return io.socket.getAsync(`/api/v1/user/${this.data.name}/boxes`).then(res => {
       this.data.boxes = res;
     }).catch(errorHandler).then(() => $scope.$apply());
   };
@@ -40,7 +40,7 @@ module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog, errorHa
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.postAsync('/me', editedData).then(() => {
+      return io.socket.patchAsync('/api/v1/me', editedData).then(() => {
         Object.assign(this.data, editedData);
         $scope.$apply();
       });

--- a/client/userMenu/user.ctrl.js
+++ b/client/userMenu/user.ctrl.js
@@ -4,7 +4,7 @@
  */
 module.exports = function(io) {
   this.logout = function () {
-    io.socket.postAsync('/logout', {}).then(() => {
+    io.socket.postAsync('/api/v1/logout', {}).then(() => {
       window.location = '/';
     }).catch(console.error.bind(console));
   };

--- a/config/routes.js
+++ b/config/routes.js
@@ -36,46 +36,46 @@ module.exports.routes = {
 
   // Boxes
 
-  'post /box': 'BoxController.add',
-  'get /b/:id': 'BoxController.get',
-  'get /boxes/mine': 'BoxController.mine',
-  'delete /b/:id': 'BoxController.delete',
-  'post /b/:id/undelete': 'BoxController.undelete',
-  'post /b/:id/edit': 'BoxController.edit',
+  'post /api/v1/box': 'BoxController.add',
+  'get /api/v1/box/:id': 'BoxController.get',
+  'get /api/v1/me/boxes': 'BoxController.mine',
+  'delete /api/v1/box/:id': 'BoxController.delete',
+  'post /api/v1/box/:id/undelete': 'BoxController.undelete',
+  'patch /api/v1/box/:id': 'BoxController.edit',
 
   // Authentication
 
-  'post /logout': 'AuthController.logout',
+  'post /api/v1/logout': 'AuthController.logout',
 
-  'post /auth/local': 'AuthController.callback',
-  'post /auth/local/:action': 'AuthController.callback',
+  'post /api/v1/auth/local': 'AuthController.callback',
+  'post /api/v1/auth/local/:action': 'AuthController.callback',
 
-  'get /auth/:provider': 'AuthController.provider',
-  'get /auth/:provider/callback': 'AuthController.callback',
-  'get /auth/:provider/:action': 'AuthController.callback',
+  'get /api/v1/auth/:provider': 'AuthController.provider',
+  'get /api/v1/auth/:provider/callback': 'AuthController.callback',
+  'get /api/v1/auth/:provider/:action': 'AuthController.callback',
 
   // Pokemon
 
-  'post /uploadpk6': 'PokemonController.uploadpk6',
-  'post /pk6/multi': 'PokemonController.uploadMultiPk6',
+  'post /api/v1/pokemon': 'PokemonController.uploadpk6',
+  'post /api/v1/pokemon/multi': 'PokemonController.uploadMultiPk6',
 
-  'get /p/:id': 'PokemonController.get',
-  'get /p/:id/download': 'PokemonController.download',
-  'delete /p/:id': 'PokemonController.delete',
-  'post /p/:id/undelete': 'PokemonController.undelete',
-  'post /p/:id/move': 'PokemonController.move',
-  'post /p/:id/edit': 'PokemonController.edit',
+  'get /api/v1/pokemon/:id': 'PokemonController.get',
+  'get /api/v1/pokemon/:id/pk6': 'PokemonController.download',
+  'delete /api/v1/pokemon/:id': 'PokemonController.delete',
+  'post /api/v1/pokemon/:id/undelete': 'PokemonController.undelete',
+  'post /api/v1/pokemon/:id/move': 'PokemonController.move',
+  'patch /api/v1/pokemon/:id': 'PokemonController.edit',
 
   // Users
-  'get /user/:name': 'UserController.get',
-  'get /user/:name/boxes': 'UserController.boxes',
-  'get /me': 'UserController.me',
-  'get /preferences': 'UserController.getPreferences',
-  'post /preferences/edit': 'UserController.editPreferences',
-  'post /me': 'UserController.editAccountInfo',
-  'post /user/:name/grantAdminStatus': 'UserController.grantAdminStatus',
-  'post /user/:name/revokeAdminStatus': 'UserController.revokeAdminStatus',
-  'post /deleteAccount': 'UserController.deleteAccount',
-  'post /changePassword': 'UserController.changePassword',
-  'get /checkUsernameAvailable': 'UserController.checkUsernameAvailable'
+  'get /api/v1/user/:name': 'UserController.get',
+  'get /api/v1/user/:name/boxes': 'UserController.boxes',
+  'get /api/v1/me': 'UserController.me',
+  'get /api/v1/me/preferences': 'UserController.getPreferences',
+  'patch /api/v1/me/preferences': 'UserController.editPreferences',
+  'patch /api/v1/me': 'UserController.editAccountInfo',
+  'post /api/v1/user/:name/grantAdminStatus': 'UserController.grantAdminStatus',
+  'post /api/v1/user/:name/revokeAdminStatus': 'UserController.revokeAdminStatus',
+  'delete /api/v1/me': 'UserController.deleteAccount',
+  'post /api/v1/changePassword': 'UserController.changePassword',
+  'get /api/v1/checkUsernameAvailable': 'UserController.checkUsernameAvailable'
 };

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -18,25 +18,25 @@ describe('AuthController', function() {
 
   describe('#login()', function () {
     it('should be able to register an account', async () => {
-      const res = await agent.post('/auth/local/register').send({
+      const res = await agent.post('/api/v1/auth/local/register').send({
         name: 'testuser1',
         password: 'hunter22',
         email: 'testuser1@gmail.com'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get('/preferences');
+      const res2 = await agent.get('/api/v1/me/preferences');
       expect(res2.statusCode).to.equal(200);
     });
 
     it('creates a box for the user after registering an account', async () => {
       const firstBoxAgent = supertest.agent(sails.hooks.http.app);
-      const res = await firstBoxAgent.post('/auth/local/register').send({
+      const res = await firstBoxAgent.post('/api/v1/auth/local/register').send({
         name: 'firstBoxTester',
         password: 'f1rstB0xTest3r',
         email: 'firstBoxTester@porybox.com'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await firstBoxAgent.get('/user/firstBoxTester/boxes');
+      const res2 = await firstBoxAgent.get('/api/v1/user/firstBoxTester/boxes');
       expect(res2.statusCode).to.equal(200);
       expect(res2.body).to.be.an.instanceof(Array);
       expect(res2.body).to.have.lengthOf(1);
@@ -47,7 +47,7 @@ describe('AuthController', function() {
     });
 
     it("shouldn't register an account with an already-existing name", async () => {
-      const res = await otherAgent.post('/auth/local/register').send({
+      const res = await otherAgent.post('/api/v1/auth/local/register').send({
         name: 'testuser1',
         password: 'beepboop',
         email: 'testuser1spoof@gmail.com'
@@ -57,7 +57,7 @@ describe('AuthController', function() {
     });
 
     it("shouldn't register an account with a password less than 8 characters", async () => {
-      const res = await otherAgent.post('/auth/local/register').send({
+      const res = await otherAgent.post('/api/v1/auth/local/register').send({
         name: 'testuser2',
         password: 'one',
         email: 'testuser2@gmail.com'
@@ -67,7 +67,7 @@ describe('AuthController', function() {
     });
 
     it('should not allow logins with invalid passwords', async () => {
-      const res = await otherAgent.post('/auth/local').send({
+      const res = await otherAgent.post('/api/v1/auth/local').send({
         name: 'testuser1',
         password: 'not_the_correct_password'
       });
@@ -76,14 +76,14 @@ describe('AuthController', function() {
     });
 
     it('does not allow a login with very similar passwords up to 72 characters', async () => {
-      const res = await otherAgent.post('/auth/local/register').send({
+      const res = await otherAgent.post('/api/v1/auth/local/register').send({
         name: 'validUsername',
         // 72 asterisks
         password: '************************************************************************',
         email: 'invalid5@porybox.com'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await invalidAgent.post('/auth/local').send({
+      const res2 = await invalidAgent.post('/api/v1/auth/local').send({
         name: 'validUsername',
         // 71 asterisks followed by an 'a'
         password: '***********************************************************************a'
@@ -93,7 +93,7 @@ describe('AuthController', function() {
     });
 
     it('should allow logins with valid passwords', async () => {
-      const res = await otherAgent.post('/auth/local').send({
+      const res = await otherAgent.post('/api/v1/auth/local').send({
         name: 'testuser1',
         password: 'hunter22'
       });
@@ -101,7 +101,7 @@ describe('AuthController', function() {
     });
 
     it('should not allow logins with invalid user but the password of another', async () => {
-      const res = await otherAgent.post('/auth/local').send({
+      const res = await otherAgent.post('/api/v1/auth/local').send({
         name: 'testuser2',
         password: 'hunter22'
       });
@@ -110,7 +110,7 @@ describe('AuthController', function() {
     });
 
     it('should not allow registration with usernames that contain special characters', async () => {
-      const res = await invalidAgent.post('/auth/local/register').send({
+      const res = await invalidAgent.post('/api/v1/auth/local/register').send({
         name: 'testuseréééé',
         password: 'blahblahblah',
         email: 'invalid@porybox.com'
@@ -120,15 +120,15 @@ describe('AuthController', function() {
     });
 
     it('should not allow registration with a username that has been deleted', async () => {
-      const res = await otherAgent.post('/auth/local/register').send({
+      const res = await otherAgent.post('/api/v1/auth/local/register').send({
         name: 'claimedUsername2',
         password: 'blahblahblah',
         email: 'invalid3@porybox.com'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await otherAgent.post('/deleteAccount').send({password: 'blahblahblah'});
+      const res2 = await otherAgent.del('/api/v1/me').send({password: 'blahblahblah'});
       expect(res2.statusCode).to.equal(200);
-      const res3 = await invalidAgent.post('/auth/local/register').send({
+      const res3 = await invalidAgent.post('/api/v1/auth/local/register').send({
         name: 'CLAIMEDUSERNAME2',
         password: 'AAAAAAAAAAAAA',
         email: 'invalid4@porybox.com'
@@ -138,7 +138,7 @@ describe('AuthController', function() {
     });
 
     it('does not allow passwords longer than 72 characters', async () => {
-      const res = await otherAgent.post('/auth/local/register').send({
+      const res = await otherAgent.post('/api/v1/auth/local/register').send({
         name: 'UNIQUE_USERNAME',
         // 73 asterisks
         password: '*************************************************************************',
@@ -155,7 +155,7 @@ describe('AuthController', function() {
       passAgent = supertest.agent(sails.hooks.http.app);
       passAgent2 = supertest.agent(sails.hooks.http.app);
       passAgent3 = supertest.agent(sails.hooks.http.app);
-      const res = await passAgent.post('/auth/local/register').send({
+      const res = await passAgent.post('/api/v1/auth/local/register').send({
         name: username,
         password: 'Correct Horse Battery Staple',
         email: `${require('crypto').randomBytes(4).toString('hex')}@porybox.com`
@@ -163,22 +163,22 @@ describe('AuthController', function() {
       expect(res.statusCode).to.equal(200);
     });
     it('allows a user to change their password', async () => {
-      const res = await passAgent.post('/changePassword').send({
+      const res = await passAgent.post('/api/v1/changePassword').send({
         oldPassword: 'Correct Horse Battery Staple',
         newPassword: 'Correct Llama Battery Staple'
       });
       expect(res.statusCode).to.equal(200);
       // do another request to make sure the current user is still authenticated
-      const res2 = await passAgent.post('/box').send({name: 'Soapbox'});
+      const res2 = await passAgent.post('/api/v1/box').send({name: 'Soapbox'});
       expect(res2.statusCode).to.equal(201);
       // log in with a different agent to make sure the new password works
-      const res3 = await passAgent2.post('/auth/local').send({
+      const res3 = await passAgent2.post('/api/v1/auth/local').send({
         name: username,
         password: 'Correct Llama Battery Staple'
       });
       expect(res3.statusCode).to.equal(200);
       // log in with the old password and make sure it doesn't work
-      const res4 = await passAgent3.post('/auth/local').send({
+      const res4 = await passAgent3.post('/api/v1/auth/local').send({
         name: username,
         password: 'Correct Horse Battery Staple'
       });
@@ -186,19 +186,19 @@ describe('AuthController', function() {
       expect(res4.body).to.equal('Error.Passport.Password.Wrong');
     });
     it('does not allow users to change their password if the given password is wrong', async () => {
-      const res = await passAgent.post('/changePassword').send({
+      const res = await passAgent.post('/api/v1/changePassword').send({
         oldPassword: 'Incorrect Horse Battery Staple',
         newPassword: 'invalid new password'
       });
       expect(res.statusCode).to.equal(403);
       // log in with the old password and make sure it still works
-      const res2 = await passAgent2.post('/auth/local').send({
+      const res2 = await passAgent2.post('/api/v1/auth/local').send({
         name: username,
         password: 'Correct Horse Battery Staple'
       });
       expect(res2.statusCode).to.equal(200);
       // log in with the new password and make sure it doesn't work
-      const res3 = await passAgent3.post('/auth/local').send({
+      const res3 = await passAgent3.post('/api/v1/auth/local').send({
         name: username,
         password: 'invalid new password'
       });
@@ -206,38 +206,38 @@ describe('AuthController', function() {
       expect(res3.body).to.equal('Error.Passport.Password.Wrong');
     });
     it('returns a 400 error if a user omits either parameter', async () => {
-      const res = await passAgent.post('/changePassword').send({newPassword: 'new password yay'});
+      const res = await passAgent.post('/api/v1/changePassword').send({newPassword: 'new pass'});
       expect(res.statusCode).to.equal(400);
-      const res2 = await passAgent.post('/changePassword').send({oldPassword: 'old password yay'});
+      const res2 = await passAgent.post('/api/v1/changePassword').send({oldPassword: 'old pass'});
       expect(res2.statusCode).to.equal(400);
     });
     it('functions properly if the new password happens to be the same as the old one', async () => {
-      const res = await passAgent.post('/changePassword').send({
+      const res = await passAgent.post('/api/v1/changePassword').send({
         oldPassword: 'Correct Horse Battery Staple',
         newPassword: 'Correct Horse Battery Staple'
       });
       expect(res.statusCode).to.equal(200);
       // do another request to make sure the current user is still authenticated
-      const res2 = await passAgent.post('/box').send({name: 'Outbox'});
+      const res2 = await passAgent.post('/api/v1/box').send({name: 'Outbox'});
       expect(res2.statusCode).to.equal(201);
       // log in with a different agent to make sure the password still works
-      const res3 = await passAgent2.post('/auth/local').send({
+      const res3 = await passAgent2.post('/api/v1/auth/local').send({
         name: username,
         password: 'Correct Horse Battery Staple'
       });
       expect(res3.statusCode).to.equal(200);
     });
     it('returns a 400 error and keeps the old password valid if new one is invalid', async () => {
-      const res = await passAgent.post('/changePassword').send({
+      const res = await passAgent.post('/api/v1/changePassword').send({
         oldPassword: 'Correct Horse Battery Staple',
         newPassword: 'blah' // Invalid password (too short)
       });
       expect(res.statusCode).to.equal(400);
       // do another request to make sure the current user is still authenticated
-      const res2 = await passAgent.post('/box').send({name: 'PO Box'});
+      const res2 = await passAgent.post('/api/v1/box').send({name: 'PO Box'});
       expect(res2.statusCode).to.equal(201);
       // log in with a different agent to make sure the old password still works
-      const res3 = await passAgent2.post('/auth/local').send({
+      const res3 = await passAgent2.post('/api/v1/auth/local').send({
         name: username,
         password: 'Correct Horse Battery Staple'
       });
@@ -249,7 +249,7 @@ describe('AuthController', function() {
     let logoutAgent;
     beforeEach(async () => {
       logoutAgent = supertest.agent(sails.hooks.http.app);
-      const res = await logoutAgent.post('/auth/local/register').send({
+      const res = await logoutAgent.post('/api/v1/auth/local/register').send({
         name: 'logoutTester',
         password: "I can't think of any funny placeholder passwords right now",
         email: 'logoutTester@porybox.com'
@@ -257,11 +257,11 @@ describe('AuthController', function() {
       expect(res.statusCode).to.equal(200);
     });
     it('allows the user to log themselves out', async () => {
-      const res = await logoutAgent.post('/logout');
+      const res = await logoutAgent.post('/api/v1/logout');
       expect(res.statusCode).to.equal(200);
 
       // Do a request to make sure it doesn't work
-      const res2 = await logoutAgent.get('/boxes/mine');
+      const res2 = await logoutAgent.get('/api/v1/me/boxes');
       expect(res2.statusCode).to.equal(403);
     });
   });

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -10,21 +10,21 @@ describe('BoxController', () => {
     otherAgent = supertest.agent(sails.hooks.http.app);
     noAuthAgent = supertest.agent(sails.hooks.http.app);
     adminAgent = supertest.agent(sails.hooks.http.app);
-    const res = await agent.post('/auth/local/register').send({
+    const res = await agent.post('/api/v1/auth/local/register').send({
       name: 'boxtester',
       password: '********',
       email: 'boxtester@boxtesting.com'
     });
     expect(res.statusCode).to.equal(200);
 
-    const res2 = await otherAgent.post('/auth/local/register').send({
+    const res2 = await otherAgent.post('/api/v1/auth/local/register').send({
       name: 'EXPLOUD_BOX',
       password: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       email: 'AAAAAAAA@BOXBOXBOXBOXBOX.com'
     });
     expect(res2.statusCode).to.equal(200);
 
-    const res3 = await adminAgent.post('/auth/local/register').send({
+    const res3 = await adminAgent.post('/api/v1/auth/local/register').send({
       name: 'box_admin',
       password: 'boxboxboxboxboxbox',
       email: 'boxadmin@porybox.com'
@@ -34,37 +34,39 @@ describe('BoxController', () => {
   });
   describe('creating a box', () => {
     it('can create a box', async () => {
-      const res = await agent.post('/box').send({name: 'Pizza Box', description: 'A box'});
+      const res = await agent.post('/api/v1/box').send({name: 'Pizza Box', description: 'A box'});
       expect(res.body.owner).to.equal('boxtester');
       expect(res.body.name).to.equal('Pizza Box');
       expect(res.body.description).to.equal('A box');
       expect(res.body.id).to.match(/^[0-9a-f]{32}$/);
     });
     it('does not allow a box to be created with an invalid/missing name', async () => {
-      const res = await agent.post('/box').send({description: 'A box', name: 5});
+      const res = await agent.post('/api/v1/box').send({description: 'A box', name: 5});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal("Invalid/missing required parameter 'name'");
 
-      const res2 = await agent.post('/box').send({description: 'A box', name: ''});
+      const res2 = await agent.post('/api/v1/box').send({description: 'A box', name: ''});
       expect(res2.statusCode).to.equal(400);
       expect(res2.body).to.equal('Invalid/missing box name');
     });
     it('does not allow a box to be created with an invalid description', async () => {
-      const res = await agent.post('/box').send({name: 'Pizza Box', description: 5});
+      const res = await agent.post('/api/v1/box').send({name: 'Pizza Box', description: 5});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Invalid box description');
     });
     it('does not allow box names longer than 300 characters', async () => {
-      const res = await agent.post('/box').send({name: 'A'.repeat(300)});
+      const res = await agent.post('/api/v1/box').send({name: 'A'.repeat(300)});
       expect(res.statusCode).to.equal(201);
-      const res2 = await agent.post('/box').send({name: 'A'.repeat(301)});
+      const res2 = await agent.post('/api/v1/box').send({name: 'A'.repeat(301)});
       expect(res2.statusCode).to.equal(400);
       expect(res2.body).to.equal('Box name too long');
     });
     it('does not allow box descriptions longer than 1000 characters', async () => {
-      const res = await agent.post('/box').send({name: 'myBox', description: 'A'.repeat(1000)});
+      const res = await agent.post('/api/v1/box')
+        .send({name: 'myBox', description: 'A'.repeat(1000)});
       expect(res.statusCode).to.equal(201);
-      const res2 = await agent.post('/box').send({name: 'myBox', description: 'A'.repeat(1001)});
+      const res2 = await agent.post('/api/v1/box')
+        .send({name: 'myBox', description: 'A'.repeat(1001)});
       expect(res2.statusCode).to.equal(400);
       expect(res2.body).to.equal('Box description too long');
     });
@@ -72,9 +74,9 @@ describe('BoxController', () => {
   describe('getting a box', () => {
     let boxId;
     before(async () => {
-      boxId = (await agent.post('/box').send({name: 'Inbox'})).body.id;
+      boxId = (await agent.post('/api/v1/box').send({name: 'Inbox'})).body.id;
       await Promise.each(['viewable', 'public', 'private'], async visibility => {
-        const res = await agent.post('/uploadpk6')
+        const res = await agent.post('/api/v1/pokemon')
           .field('box', boxId)
           .field('visibility', visibility)
           .attach('pk6', __dirname + '/pkmn1.pk6');
@@ -82,7 +84,7 @@ describe('BoxController', () => {
       });
     });
     it('allows a user to view the contents of their box by ID', async () => {
-      const box = (await agent.get(`/b/${boxId}`)).body;
+      const box = (await agent.get(`/api/v1/box/${boxId}`)).body;
       expect(box.id).to.equal(boxId);
       expect(box.contents).to.have.lengthOf(3);
       expect(box.contents[0].pid).to.exist();
@@ -99,7 +101,7 @@ describe('BoxController', () => {
       expect(box.pageNum).to.equal(1);
     });
     it('allows third parties to view a box, filtering contents by pokemon visibility', async () => {
-      const box = (await otherAgent.get(`/b/${boxId}`)).body;
+      const box = (await otherAgent.get(`/api/v1/box/${boxId}`)).body;
       expect(box.id).to.equal(boxId);
       expect(box.contents[0].visibility).to.equal('viewable');
       expect(box.contents[0].pid).to.not.exist();
@@ -114,7 +116,7 @@ describe('BoxController', () => {
       expect(box.pageNum).to.equal(1);
     });
     it('allows admins to view the full contents of a box by ID', async () => {
-      const box = (await adminAgent.get(`/b/${boxId}`)).body;
+      const box = (await adminAgent.get(`/api/v1/box/${boxId}`)).body;
       expect(box.id).to.equal(boxId);
       expect(box.contents[0].visibility).to.equal('viewable');
       expect(box.contents[0].pid).to.exist();
@@ -132,7 +134,7 @@ describe('BoxController', () => {
       expect(box.pageNum).to.equal(1);
     });
     it('allows an unauthenticated user to view a box by ID', async () => {
-      const res = await noAuthAgent.get(`/b/${boxId}`);
+      const res = await noAuthAgent.get(`/api/v1/box/${boxId}`);
       expect(res.statusCode).to.equal(200);
       const box = res.body;
       expect(box.id).to.equal(boxId);
@@ -149,7 +151,7 @@ describe('BoxController', () => {
       expect(box.pageNum).to.equal(1);
     });
     it('allows the properties of the Pokémon in the box to be specified by query', async () => {
-      const res = await agent.get(`/b/${boxId}`).query({pokemonFields: 'speciesName'});
+      const res = await agent.get(`/api/v1/box/${boxId}`).query({pokemonFields: 'speciesName'});
       expect(res.statusCode).to.equal(200);
       expect(res.body.id).to.equal(boxId);
       expect(res.body.contents).to.eql([
@@ -159,8 +161,9 @@ describe('BoxController', () => {
       ]);
     });
     it('does not allow private properties of Pokémon to be accessed by the query', async () => {
-      const publicPid = (await agent.get(`/b/${boxId}`)).body.contents[1].pid;
-      const res = await otherAgent.get(`/b/${boxId}`).query({pokemonFields: 'speciesName,pid'});
+      const publicPid = (await agent.get(`/api/v1/box/${boxId}`)).body.contents[1].pid;
+      const res = await otherAgent.get(`/api/v1/box/${boxId}`)
+        .query({pokemonFields: 'speciesName,pid'});
       expect(res.statusCode).to.equal(200);
       expect(res.body.id).to.equal(boxId);
       expect(res.body.contents).to.eql([
@@ -169,7 +172,8 @@ describe('BoxController', () => {
       ]);
     });
     it('does not allow internal properties of Pokémon to be accessed by the query', async () => {
-      const res = await agent.get(`/b/${boxId}`).query({pokemonFields: 'speciesName,_rawPk6'});
+      const res = await agent.get(`/api/v1/box/${boxId}`)
+        .query({pokemonFields: 'speciesName,_rawPk6'});
       expect(res.statusCode).to.equal(200);
       expect(res.body.id).to.equal(boxId);
       expect(res.body.contents).to.eql([
@@ -185,13 +189,13 @@ describe('BoxController', () => {
       pageSize = sails.services.constants.BOX_PAGE_SIZE;
       expect(pageSize).to.be.a('number');
       expect(pageSize).to.be.above(0);
-      const res = await agent.post('/box').send({name: 'multibox'});
+      const res = await agent.post('/api/v1/box').send({name: 'multibox'});
       expect(res.statusCode).to.equal(201);
       box = res.body;
       const pkmnData = require('fs').readFileSync(`${__dirname}/pkmn1.pk6`, {encoding: 'base64'});
       pkmnList = [];
       for (const amount of [pageSize, pageSize, 1]) {
-        const res2 = await agent.post('/pk6/multi').send({files: _.times(amount, () => ({
+        const res2 = await agent.post('/api/v1/pokemon/multi').send({files: _.times(amount, () => ({
           box: box.id, visibility: _.sample(['public', 'private', 'viewable']), data: pkmnData
         }))});
         expect(res2.statusCode).to.equal(201);
@@ -201,7 +205,7 @@ describe('BoxController', () => {
       }
     });
     it('returns the first 50 items if no page parameter is provided', async () => {
-      const res = await agent.get(`/b/${box.id}`);
+      const res = await agent.get(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(200);
       expect(_.map(res.body.contents, 'id')).to.eql(_.map(pkmnList.slice(0, pageSize), 'id'));
       expect(res.body.pageNum).to.equal(1);
@@ -209,7 +213,7 @@ describe('BoxController', () => {
       expect(res.body.totalItemCount).to.equal(2 * pageSize + 1);
     });
     it('adjusts the results for privacy if the user is not the owner', async () => {
-      const res = await otherAgent.get(`/b/${box.id}`);
+      const res = await otherAgent.get(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(200);
       const nonPrivatePkmn = pkmnList.filter(pkmn => pkmn.visibility !== 'private');
       expect(_.map(res.body.contents, 'id')).to.eql(_.map(nonPrivatePkmn.slice(0, pageSize), 'id'));
@@ -218,7 +222,7 @@ describe('BoxController', () => {
       expect(res.body.totalItemCount).to.equal(nonPrivatePkmn.length);
     });
     it('returns returns different contents depending on a page parameter', async () => {
-      const res = await agent.get(`/b/${box.id}`).query({page: 2});
+      const res = await agent.get(`/api/v1/box/${box.id}`).query({page: 2});
       expect(res.statusCode).to.equal(200);
       const expectedList = pkmnList.slice(pageSize, pageSize * 2);
       expect(_.map(res.body.contents, 'id')).to.eql(_.map(expectedList, 'id'));
@@ -226,7 +230,7 @@ describe('BoxController', () => {
       expect(res.body.totalPageCount).to.equal(3);
       expect(res.body.totalItemCount).to.equal(2 * pageSize + 1);
 
-      const res2 = await agent.get(`/b/${box.id}`).query({page: 3});
+      const res2 = await agent.get(`/api/v1/box/${box.id}`).query({page: 3});
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmnList[pageSize * 2].id]);
       expect(res2.body.pageNum).to.equal(3);
@@ -234,34 +238,35 @@ describe('BoxController', () => {
       expect(res2.body.totalItemCount).to.equal(2 * pageSize + 1);
     });
     it('returns a 404 error if the page parameter is too large', async () => {
-      const res = await agent.get(`/b/${box.id}`).query({page: 4});
+      const res = await agent.get(`/api/v1/box/${box.id}`).query({page: 4});
       expect(res.statusCode).to.equal(404);
 
-      const res2 = await otherAgent.get(`/b/${box.id}`).query({page: 3});
+      const res2 = await otherAgent.get(`/api/v1/box/${box.id}`).query({page: 3});
       expect(res2.statusCode).to.equal(404);
     });
     it('returns a 404 error if the page parameter is invalid', async () => {
-      const res = await agent.get(`/b/${box.id}`).query({page: 'foo'});
+      const res = await agent.get(`/api/v1/box/${box.id}`).query({page: 'foo'});
       expect(res.statusCode).to.equal(404);
     });
   });
   describe("getting a user's boxes", () => {
     let box1, box2, unlistedBox, otherBox;
     beforeEach(async () => {
-      const res = await agent.post('/box').send({name: 'Jukebox'});
+      const res = await agent.post('/api/v1/box').send({name: 'Jukebox'});
       expect(res.statusCode).to.equal(201);
       box1 = res.body;
-      const res2 = await agent.post('/box').send({name: 'Sandbox'});
+      const res2 = await agent.post('/api/v1/box').send({name: 'Sandbox'});
       expect(res2.statusCode).to.equal(201);
       box2 = res2.body;
-      const res3 = await agent.post('/box').send({name: 'Penalty Box', visibility: 'unlisted'});
+      const res3 = await agent.post('/api/v1/box')
+        .send({name: 'Penalty Box', visibility: 'unlisted'});
       expect(res3.statusCode).to.equal(201);
       unlistedBox = res3.body;
-      const res4 = await otherAgent.post('/box').send({name: "Pandora's Box"});
+      const res4 = await otherAgent.post('/api/v1/box').send({name: "Pandora's Box"});
       expect(res4.statusCode).to.equal(201);
       otherBox = res4.body;
       await Promise.each(['viewable', 'public', 'private'], async visibility => {
-        const res = await agent.post('/uploadpk6')
+        const res = await agent.post('/api/v1/pokemon')
           .attach('pk6', __dirname + '/pkmn1.pk6')
           .field('box', box1.id)
           .field('visibility', visibility);
@@ -269,10 +274,10 @@ describe('BoxController', () => {
       });
     });
     it('allows a user to get their own boxes', async () => {
-      const res = await agent.get('/boxes/mine');
+      const res = await agent.get('/api/v1/me/boxes');
       expect(res.statusCode).to.equal(302);
       expect(res.header.location).to.equal('/user/boxtester/boxes');
-      const myBoxes = (await agent.get('/user/boxtester/boxes')).body;
+      const myBoxes = (await agent.get('/api/v1/user/boxtester/boxes')).body;
       const boxIds = _.map(myBoxes, 'id');
       expect(boxIds).to.include(box1.id);
       expect(boxIds).to.include(box2.id);
@@ -282,7 +287,7 @@ describe('BoxController', () => {
       expect(boxContents).to.eql([]);
     });
     it("allows a third party to get a user's listed boxes", async () => {
-      const boxes = (await otherAgent.get('/user/boxtester/boxes')).body;
+      const boxes = (await otherAgent.get('/api/v1/user/boxtester/boxes')).body;
       const listedBoxIds = _.map(boxes, 'id');
       expect(listedBoxIds).to.include(box1.id);
       expect(listedBoxIds).to.include(box2.id);
@@ -292,7 +297,7 @@ describe('BoxController', () => {
       expect(boxContents).to.eql([]);
     });
     it("allows an unauthenticated user to get a user's listed boxes", async () => {
-      const boxes = (await noAuthAgent.get('/user/boxtester/boxes')).body;
+      const boxes = (await noAuthAgent.get('/api/v1/user/boxtester/boxes')).body;
       const listedBoxIds = _.map(boxes, 'id');
       expect(listedBoxIds).to.include(box1.id);
       expect(listedBoxIds).to.include(box2.id);
@@ -302,7 +307,7 @@ describe('BoxController', () => {
       expect(boxContents).to.eql([]);
     });
     it("allows an admin to get all of a user's boxes", async () => {
-      const boxes = (await adminAgent.get('/user/boxtester/boxes')).body;
+      const boxes = (await adminAgent.get('/api/v1/user/boxtester/boxes')).body;
       const boxIds = _.map(boxes, 'id');
       expect(boxIds).to.include(box1.id);
       expect(boxIds).to.include(box2.id);
@@ -312,16 +317,16 @@ describe('BoxController', () => {
       expect(boxContents).to.eql([]);
     });
     it('does not leak internal properties of a box to the client', async () => {
-      const box = (await agent.get(`/b/${box1.id}`)).body;
+      const box = (await agent.get(`/api/v1/box/${box1.id}`)).body;
       expect(box._markedForDeletion).to.not.exist();
       expect(box._orderedIds).to.not.exist();
     });
     it('adds newly-created boxes to the end of the box list', async () => {
-      const res = await agent.get('/user/boxtester/boxes');
+      const res = await agent.get('/api/v1/user/boxtester/boxes');
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.post('/box').send({name: 'Shadowbox'});
+      const res2 = await agent.post('/api/v1/box').send({name: 'Shadowbox'});
       expect(res2.statusCode).to.equal(201);
-      const res3 = await agent.get('/user/boxtester/boxes');
+      const res3 = await agent.get('/api/v1/user/boxtester/boxes');
       expect(res3.statusCode).to.equal(200);
       expect(res3.body).to.eql(res.body.concat(res2.body));
     });
@@ -335,129 +340,129 @@ describe('BoxController', () => {
       sails.services.constants.BOX_DELETION_DELAY = 2000;
     });
     beforeEach(async () => {
-      const res = await agent.post('/box').send({name: 'Boombox'});
+      const res = await agent.post('/api/v1/box').send({name: 'Boombox'});
       expect(res.statusCode).to.equal(201);
       box = res.body;
-      const res2 = await agent.post('/uploadpk6')
+      const res2 = await agent.post('/api/v1/pokemon')
         .field('box', box.id)
         .attach('pk6', `${__dirname}/pkmn1.pk6`);
       expect(res2.statusCode).to.equal(201);
       pkmn = res2.body;
     });
     it('does not allow a user to delete their last box', async () => {
-      const initialLength = (await agent.get('/user/boxtester/boxes')).body.length;
+      const initialLength = (await agent.get('/api/v1/user/boxtester/boxes')).body.length;
       await Promise.all(_.times(5, async () => {
-        const res = await agent.post('/box').send({name: 'Fare Box'});
+        const res = await agent.post('/api/v1/box').send({name: 'Fare Box'});
         expect(res.statusCode).to.equal(201);
       }));
-      const res2 = await agent.get('/user/boxtester/boxes');
+      const res2 = await agent.get('/api/v1/user/boxtester/boxes');
       expect(res2.body.length).to.equal(initialLength + 5);
       expect(res2.statusCode).to.equal(200);
       await Promise.each(res2.body.slice(1), async box => {
-        const res3 = await agent.del(`/b/${box.id}`);
+        const res3 = await agent.del(`/api/v1/box/${box.id}`);
         expect(res3.statusCode).to.equal(202);
       });
-      const res4 = await agent.del(`/b/${res2.body[0].id}`);
+      const res4 = await agent.del(`/api/v1/box/${res2.body[0].id}`);
       expect(res4.statusCode).to.equal(400);
-      const res5 = await agent.get('/user/boxtester/boxes');
+      const res5 = await agent.get('/api/v1/user/boxtester/boxes');
       expect(res5.body.length).to.equal(1);
     });
     it('does not allow users to delete boxes that belong to other users', async () => {
-      const res = await otherAgent.del(`/b/${box.id}`);
+      const res = await otherAgent.del(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(403);
     });
     it('returns a 404 error after fetching a deleted box', async () => {
-      const res = await agent.del(`/b/${box.id}`);
+      const res = await agent.del(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.statusCode).to.equal(404);
     });
     it('also deletes all Pokemon contents when a box is deleted', async () => {
-      await agent.del(`/b/${box.id}`);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      await agent.del(`/api/v1/box/${box.id}`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(404);
       await Promise.delay(sails.services.constants.BOX_DELETION_DELAY);
-      const res3 = await agent.get(`/p/${pkmn.id}`);
+      const res3 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res3.statusCode).to.equal(404);
     });
     it('allows deleted boxes to be undeleted shortly afterwards', async () => {
-      await agent.del(`/b/${box.id}`);
-      const res = await agent.post(`/b/${box.id}/undelete`);
+      await agent.del(`/api/v1/box/${box.id}`);
+      const res = await agent.post(`/api/v1/box/${box.id}/undelete`);
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.id).to.equal(box.id);
       await Promise.delay(sails.services.constants.BOX_DELETION_DELAY);
-      const res3 = await agent.get(`/b/${box.id}`);
+      const res3 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res3.statusCode).to.equal(200);
       expect(res3.body.id).to.equal(box.id);
     });
     it('does not allow boxes to be undeleted once some time has elapsed', async () => {
-      await agent.del(`/b/${box.id}`);
+      await agent.del(`/api/v1/box/${box.id}`);
       await Promise.delay(sails.services.constants.BOX_DELETION_DELAY);
-      const res = await agent.post(`/b/${box.id}/undelete`);
+      const res = await agent.post(`/api/v1/box/${box.id}/undelete`);
       expect(res.statusCode).to.equal(404);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.statusCode).to.equal(404);
     });
     it('does not allow users to undelete boxes that belong to other users', async () => {
-      await agent.del(`/b/${box.id}`);
-      const res = await otherAgent.post(`/b/${box.id}/undelete`);
+      await agent.del(`/api/v1/box/${box.id}`);
+      const res = await otherAgent.post(`/api/v1/box/${box.id}/undelete`);
       expect(res.statusCode).to.equal(404);
     });
     it('does not allow a user to undelete a pokemon if its box was deleted', async () => {
-      await agent.del(`/b/${box.id}`);
-      const res = await agent.post(`/p/${pkmn.id}/undelete`);
+      await agent.del(`/api/v1/box/${box.id}`);
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/undelete`);
       expect(res.statusCode).to.equal(400);
     });
     it('allows admins to delete a box belonging to anyone', async () => {
-      const res = await adminAgent.del(`/b/${box.id}`);
+      const res = await adminAgent.del(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(202);
-      expect((await agent.get(`/b/${box.id}`)).statusCode).to.equal(404);
+      expect((await agent.get(`/api/v1/box/${box.id}`)).statusCode).to.equal(404);
     });
     it('allows admins to undelete a box belonging to anyone', async () => {
-      const res = await agent.del(`/b/${box.id}`);
+      const res = await agent.del(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await adminAgent.post(`/b/${box.id}/undelete`);
+      const res2 = await adminAgent.post(`/api/v1/box/${box.id}/undelete`);
       expect(res2.statusCode).to.equal(200);
-      expect((await agent.get(`/b/${box.id}`)).statusCode).to.equal(200);
+      expect((await agent.get(`/api/v1/box/${box.id}`)).statusCode).to.equal(200);
     });
     it("restores a box's contents after undeleting it", async () => {
-      await agent.del(`/b/${box.id}`);
-      const res = await agent.get(`/p/${pkmn.id}`);
+      await agent.del(`/api/v1/box/${box.id}`);
+      const res = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(404);
-      await agent.post(`/b/${box.id}/undelete`);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      await agent.post(`/api/v1/box/${box.id}/undelete`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.id).to.equal(pkmn.id);
     });
     it('deletes a box immediately if the `immediately` parameter is set to true', async () => {
-      await agent.del(`/b/${box.id}`).send({immediately: true});
-      const res = await agent.post(`/b/${box.id}/undelete`);
+      await agent.del(`/api/v1/box/${box.id}`).send({immediately: true});
+      const res = await agent.post(`/api/v1/box/${box.id}/undelete`);
       expect(res.statusCode).to.equal(404);
     });
     it('does not hang the server while waiting for a box to be fully deleted', async () => {
-      await agent.del(`/b/${box.id}`);
+      await agent.del(`/api/v1/box/${box.id}`);
       const timer = Promise.delay(sails.services.constants.BOX_DELETION_DELAY);
-      await agent.get('/');
+      await agent.get('/api/v1/');
       expect(timer.isFulfilled()).to.be.false();
     });
     it('does not show deleted boxes in box listings', async () => {
-      const res = await agent.get('/user/boxtester/boxes');
+      const res = await agent.get('/api/v1/user/boxtester/boxes');
       expect(_.map(res.body, 'id')).to.include(box.id);
-      await agent.del(`/b/${box.id}`);
-      const res2 = await agent.get('/user/boxtester/boxes');
+      await agent.del(`/api/v1/box/${box.id}`);
+      const res2 = await agent.get('/api/v1/user/boxtester/boxes');
       expect(_.map(res2.body, 'id')).to.not.include(box.id);
     });
     it('does not cause errors if the same box is deleted in two separate requests', async () => {
-      const res = await agent.del(`/b/${box.id}`);
+      const res = await agent.del(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.post(`/b/${box.id}/undelete`);
+      const res2 = await agent.post(`/api/v1/box/${box.id}/undelete`);
       expect(res2.statusCode).to.equal(200);
-      const res3 = await agent.del(`/b/${box.id}`);
+      const res3 = await agent.del(`/api/v1/box/${box.id}`);
       expect(res3.statusCode).to.equal(202);
       await Promise.delay(sails.services.constants.BOX_DELETION_DELAY);
-      const res4 = await agent.get(`/b/${box.id}`);
+      const res4 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res4.statusCode).to.equal(404);
     });
     after(() => {
@@ -467,88 +472,92 @@ describe('BoxController', () => {
   describe('editing a box', () => {
     let box;
     beforeEach(async () => {
-      const res = await agent.post('/box').send({name: 'Pillbox', visibility: 'listed'});
+      const res = await agent.post('/api/v1/box').send({name: 'Pillbox', visibility: 'listed'});
       expect(res.statusCode).to.equal(201);
       box = res.body;
     });
     it('allows a user to edit the name of their box', async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({name: 'Boxfish'});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({name: 'Boxfish'});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.body.name).to.equal('Boxfish');
       expect(res2.body.description).to.equal('');
       expect(res2.body.visibility).to.equal('listed');
     });
     it('allows a user to edit the description of their box', async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({description: 'Contains things'});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({description: 'Contains things'});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.body.name).to.equal('Pillbox');
       expect(res2.body.description).to.equal('Contains things');
       expect(res2.body.visibility).to.equal('listed');
     });
     it('allows a user to edit the visibility of their box', async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({visibility: 'unlisted'});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({visibility: 'unlisted'});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.body.name).to.equal('Pillbox');
       expect(res2.body.description).to.equal('');
       expect(res2.body.visibility).to.equal('unlisted');
     });
     it('allows a user to edit multiple box properties at once', async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({name: 'a', visibility: 'unlisted'});
+      const res = await agent.patch(`/api/v1/box/${box.id}`)
+        .send({name: 'a', visibility: 'unlisted'});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.body.name).to.equal('a');
       expect(res2.body.description).to.equal('');
       expect(res2.body.visibility).to.equal('unlisted');
     });
     it('does not allow invalid properties to be edited', async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({visibility: 'unlisted', owner: 'b'});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({
+        visibility: 'unlisted',
+        owner: 'b'
+      });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.body.name).to.equal('Pillbox');
       expect(res2.body.description).to.equal('');
       expect(res2.body.visibility).to.equal('unlisted');
       expect(res2.body.owner).to.not.equal('b');
     });
     it('returns a 400 error if no valid properties are specified', async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({owner: 'b', contents: []});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({owner: 'b', contents: []});
       expect(res.statusCode).to.equal(400);
     });
     it('returns a 404 error if an invalid box ID is given', async () => {
-      const res = await agent.post('/b/NotARealBoxID/edit').send({visibility: 'unlisted'});
+      const res = await agent.patch('/api/v1/box/NotARealBoxID').send({visibility: 'unlisted'});
       expect(res.statusCode).to.equal(404);
     });
     it("does not allow a user to edit someone else's box", async () => {
-      const res = await otherAgent.post(`/b/${box.id}/edit`).send({description: 'a box'});
+      const res = await otherAgent.patch(`/api/v1/box/${box.id}`).send({description: 'a box'});
       expect(res.statusCode).to.equal(403);
     });
     it("allows an admin to edit anyone's box", async () => {
-      const res = await adminAgent.post(`/b/${box.id}/edit`).send({description: 'a box'});
+      const res = await adminAgent.patch(`/api/v1/box/${box.id}`).send({description: 'a box'});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.name).to.equal('Pillbox');
       expect(res2.body.description).to.equal('a box');
       expect(res.body.visibility).to.equal('listed');
     });
     it('does not allow a deleted box to be edited', async () => {
-      const res = await agent.del(`/b/${box.id}`);
+      const res = await agent.del(`/api/v1/box/${box.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.post(`/b/${box.id}/edit`).send({description: 'a box'});
+      const res2 = await agent.patch(`/api/v1/box/${box.id}`).send({description: 'a box'});
       expect(res2.statusCode).to.equal(404);
     });
     it("does not allow a box's name to be edited to the empty string", async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({name: ''});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({name: ''});
       expect(res.statusCode).to.equal(400);
     });
     it("does not allow a box's name to be edited to longer than 300 chars", async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({name: 'A'.repeat(301)});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({name: 'A'.repeat(301)});
       expect(res.statusCode).to.equal(400);
     });
     it("does not allow a box's description to be edited to longer than 1000 chars", async () => {
-      const res = await agent.post(`/b/${box.id}/edit`).send({name: 'A'.repeat(1001)});
+      const res = await agent.patch(`/api/v1/box/${box.id}`).send({name: 'A'.repeat(1001)});
       expect(res.statusCode).to.equal(400);
     });
   });

--- a/test/controller/main.js
+++ b/test/controller/main.js
@@ -4,7 +4,7 @@ const request = require('supertest');
 describe('404', () => {
   it('should return 404 on nonexistent path', (done) => {
     request(sails.hooks.http.app)
-      .post('/thiswillneverbevalid')
+      .post('/api/v1/thiswillneverbevalid')
       .expect(404, done);
   });
 });

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -10,28 +10,28 @@ describe('PokemonController', () => {
     otherAgent = supertest.agent(sails.hooks.http.app);
     noAuthAgent = supertest.agent(sails.hooks.http.app);
     adminAgent = supertest.agent(sails.hooks.http.app);
-    const res = await agent.post('/auth/local/register').send({
+    const res = await agent.post('/api/v1/auth/local/register').send({
       name: 'pk6tester',
       password: '********',
       email: 'pk6tester@pk6testing.com'
     });
     expect(res.statusCode).to.equal(200);
 
-    const res2 = await otherAgent.post('/auth/local/register').send({
+    const res2 = await otherAgent.post('/api/v1/auth/local/register').send({
       name: 'EXPLOUD_BOT',
       password: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       email: 'AAAAAAAA@AAAAAAAA.com'
     });
     expect(res2.statusCode).to.equal(200);
 
-    const res3 = await adminAgent.post('/auth/local/register').send({
+    const res3 = await adminAgent.post('/api/v1/auth/local/register').send({
       name: 'pokemon_admin',
       password: 'correct horse battery staple',
       email: 'pokemon_admin@porybox.com'
     });
     expect(res3.statusCode).to.equal(200);
 
-    const res4 = await agent.post('/box').send({name: 'Boxers'});
+    const res4 = await agent.post('/api/v1/box').send({name: 'Boxers'});
     expect(res4.statusCode).to.equal(201);
     generalPurposeBox = res4.body.id;
 
@@ -40,12 +40,12 @@ describe('PokemonController', () => {
   describe('upload', () => {
     let otherBox;
     before(async () => {
-      const res = await otherAgent.post('/box').send({name: 'carBoxyl'});
+      const res = await otherAgent.post('/api/v1/box').send({name: 'carBoxyl'});
       expect(res.statusCode).to.equal(201);
       otherBox = res.body.id;
     });
     it('should be able to upload a pk6 file and receive a parsed version', async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/pkmn1.pk6`);
       expect(res.statusCode).to.equal(201);
@@ -58,66 +58,66 @@ describe('PokemonController', () => {
       expect(res.body.id).to.match(/^[0-9a-f]{32}$/);
     });
     it('should identify uploaded things as clones', async () => {
-      const res1 = await agent.post('/uploadpk6')
+      const res1 = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/pkmn2.pk6`);
       expect(res1.statusCode).to.equal(201);
       expect(res1.body.isUnique).to.be.true();
-      const res2 = await agent.post('/uploadpk6')
+      const res2 = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/pkmn2.pk6`);
       expect(res2.statusCode).to.equal(201);
       expect(res2.body.isUnique).to.be.false();
     });
     it("should reject uploads that aren't pk6 files", async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/not_a_pk6_file.txt`);
       expect(res.statusCode).to.equal(400);
     });
     it('should not allow a user to upload a pk6 file without specifying a box', async () => {
-      const res = await agent.post('/uploadpk6').attach('pk6', `${__dirname}/pkmn1.pk6`);
+      const res = await agent.post('/api/v1/pokemon').attach('pk6', `${__dirname}/pkmn1.pk6`);
       expect(res.statusCode).to.equal(400);
     });
     it('should return a 404 error if the specified box does not exist', async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', 'not a real box id')
         .attach('pk6', `${__dirname}/pkmn1.pk6`);
       expect(res.statusCode).to.equal(404);
     });
     it('should return a 403 error if the specified box belongs to someone else', async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', otherBox)
         .attach('pk6', `${__dirname}/pkmn1.pk6`);
       expect(res.statusCode).to.equal(403);
     });
     it('should not allow kyurem-white to be uploaded', async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/kyurem-w.pk6`);
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Kyurem-White may not be uploaded');
     });
     it('should not allow a pokemon with invalid move IDs to be uploaded', async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/invalid-moves.pk6`);
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Failed to parse the provided file');
     });
     it('can handle concurrent uploads to the same box without losing anything', async () => {
-      const res = await agent.get(`/b/${generalPurposeBox}`);
+      const res = await agent.get(`/api/v1/box/${generalPurposeBox}`);
       expect(res.statusCode).to.equal(200);
       const initialCount = res.body.contents.length;
       expect(initialCount).to.be.a('number');
       const newIds = await Promise.all(_.times(10, async () => {
-        const res2 = await agent.post('/uploadpk6')
+        const res2 = await agent.post('/api/v1/pokemon')
           .field('box', generalPurposeBox)
           .attach('pk6', `${__dirname}/pkmn1.pk6`);
         expect(res2.statusCode).to.equal(201);
         return res2.body.id;
       }));
-      const res3 = await agent.get(`/b/${generalPurposeBox}`);
+      const res3 = await agent.get(`/api/v1/box/${generalPurposeBox}`);
       expect(res3.body.contents.length).to.equal(initialCount + 10);
       expect(_.map(res3.body.contents.slice(-10), 'id').sort()).to.eql(newIds.sort());
     });
@@ -147,7 +147,7 @@ describe('PokemonController', () => {
         {box: generalPurposeBox, visibility: 'public', data: pk6Data},
         {box: generalPurposeBox, visibility: 'private', data: pk6Data}
       ];
-      const res = await agent.post('/pk6/multi').send({files});
+      const res = await agent.post('/api/v1/pokemon/multi').send({files});
       expect(res.statusCode).to.equal(201);
       expect(res.body).to.be.an.instanceof(Array);
       expect(res.body).to.have.lengthOf(3);
@@ -158,7 +158,7 @@ describe('PokemonController', () => {
       expect(_.map(res.body, 'created.box')).to.eql(_.times(3, () => generalPurposeBox));
     });
     it("defaults to the user's default upload visibility if none is provided", async () => {
-      const res = await agent.post('/pk6/multi').send({files: [
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, data: pk6Data}
       ]});
       expect(res.statusCode).to.equal(201);
@@ -166,29 +166,29 @@ describe('PokemonController', () => {
       expect(res.body).to.have.lengthOf(1);
       expect(res.body[0].success).to.be.true();
       expect(res.body[0].error).to.be.null();
-      const res2 = await agent.get('/preferences');
+      const res2 = await agent.get('/api/v1/me/preferences');
       expect(res2.statusCode).to.equal(200);
       const userDefaultVisibility = res2.body.defaultPokemonVisibility;
       expect(res.body[0].created.visibility).to.equal(userDefaultVisibility);
     });
     it('returns a 400 error if the `files` argument is not an array', async () => {
       const notAnArray = {length: 3, 0: 'foo', 1: 'bar', 2: 'baz'};
-      const res = await agent.post('/pk6/multi').send({files: notAnArray});
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: notAnArray});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Invalid files array');
     });
     it('returns a 400 error if the `files` array is empty', async () => {
-      const res = await agent.post('/pk6/multi').send({files: []});
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: []});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('No files uploaded');
     });
     it('returns a 400 error if the `files` array has a length greater than 50', async () => {
-      const res = await agent.post('/pk6/multi').send({files: _.times(51, () => ({}))});
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: _.times(51, () => ({}))});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('A maximum of 50 files may be uploaded at a time');
     });
     it('returns a 400 error if any provided visibility is invalid', async () => {
-      const res = await agent.post('/pk6/multi').send({files: [
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: generalPurposeBox, visibility: 'private', data: pk6Data},
         {box: generalPurposeBox, visibility: 'HI THANKS FOR READING THE UNIT TESTS', data: pk6Data},
@@ -198,7 +198,7 @@ describe('PokemonController', () => {
       expect(res.body).to.equal('Invalid Pokémon visibility');
     });
     it('returns a 400 error if any box IDs are missing/invalid', async () => {
-      const res = await agent.post('/pk6/multi').send({files: [
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {visibility: 'private', data: pk6Data},
@@ -207,7 +207,7 @@ describe('PokemonController', () => {
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Missing/invalid box ID');
 
-      const res2 = await agent.post('/pk6/multi').send({files: [
+      const res2 = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: ['this is an array'], visibility: 'private', data: pk6Data},
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
@@ -217,12 +217,12 @@ describe('PokemonController', () => {
       expect(res2.body).to.equal('Missing/invalid box ID');
     });
     it('does not accept Pokémon with invalid pk6 data', async () => {
-      const res = await agent.post('/pk6/multi').send({files: [
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: generalPurposeBox, visibility: 'private', data: invalidPk6Data1},
         {box: generalPurposeBox, visibility: 'public', data: pk6Data}
       ]});
-      const res2 = await agent.post('/pk6/multi').send({files: [
+      const res2 = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: generalPurposeBox, visibility: 'private', data: invalidPk6Data2},
         {box: generalPurposeBox, visibility: 'public', data: pk6Data}
@@ -241,7 +241,7 @@ describe('PokemonController', () => {
       });
     });
     it("does not accept box IDs that don't exist", async () => {
-      const res = await agent.post('/pk6/multi').send({files: [
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: generalPurposeBox + 'extra not-box-id bit', visibility: 'private', data: pk6Data},
         {box: generalPurposeBox, visibility: 'public', data: pk6Data}
@@ -258,10 +258,10 @@ describe('PokemonController', () => {
       expect(res.body[1].error).to.equal('Not Found');
     });
     it('does not accept box IDs that belong to another user', async () => {
-      const res = await otherAgent.post('/box').send({name: 'Outbox'});
+      const res = await otherAgent.post('/api/v1/box').send({name: 'Outbox'});
       expect(res.statusCode).to.equal(201);
       const otherBox = res.body;
-      const res2 = await agent.post('/pk6/multi').send({files: [
+      const res2 = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: otherBox.id, visibility: 'private', data: pk6Data},
         {box: generalPurposeBox, visibility: 'public', data: pk6Data}
@@ -278,7 +278,7 @@ describe('PokemonController', () => {
       expect(res2.body[1].error).to.equal('Forbidden');
     });
     it('does not accept kyurem-w or kyurem-b', async () => {
-      const res = await agent.post('/pk6/multi').send({files: [
+      const res = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: generalPurposeBox, visibility: 'private', data: kyuremW},
         {box: generalPurposeBox, visibility: 'public', data: pk6Data}
@@ -295,19 +295,19 @@ describe('PokemonController', () => {
       expect(res.body[1].error).to.equal('Kyurem-White may not be uploaded');
     });
     it('enters the results into the correct boxes with the correct settings', async () => {
-      const res = await agent.post('/box').send({name: 'Checkbox'});
+      const res = await agent.post('/api/v1/box').send({name: 'Checkbox'});
       expect(res.statusCode).to.equal(201);
       const box1 = res.body;
 
-      const res2 = await agent.post('/box').send({name: 'Bounding Box'});
+      const res2 = await agent.post('/api/v1/box').send({name: 'Bounding Box'});
       expect(res2.statusCode).to.equal(201);
       const box2 = res2.body;
 
-      const res3 = await agent.get(`/b/${generalPurposeBox}`);
+      const res3 = await agent.get(`/api/v1/box/${generalPurposeBox}`);
       expect(res3.statusCode).to.equal(200);
       const initialContents = res3.body.contents;
 
-      const res4 = await agent.post('/pk6/multi').send({files: [
+      const res4 = await agent.post('/api/v1/pokemon/multi').send({files: [
         {box: generalPurposeBox, visibility: 'viewable', data: pk6Data},
         {box: box1.id, visibility: 'public', data: pk6Data},
         {box: box2.id, visibility: 'private', data: pk6Data},
@@ -325,13 +325,13 @@ describe('PokemonController', () => {
       expect(res4.body[5].created).to.be.null();
       expect(res4.body[5].error).to.equal('Failed to parse the provided file');
 
-      const res5 = await agent.get(`/b/${box1.id}`);
+      const res5 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res5.statusCode).to.equal(200);
       const updatedBox1 = res5.body;
-      const res6 = await agent.get(`/b/${box2.id}`);
+      const res6 = await agent.get(`/api/v1/box/${box2.id}`);
       expect(res6.statusCode).to.equal(200);
       const updatedBox2 = res6.body;
-      const res7 = await agent.get(`/b/${generalPurposeBox}`);
+      const res7 = await agent.get(`/api/v1/box/${generalPurposeBox}`);
       expect(res7.statusCode).to.equal(200);
       const updatedInitialBox = res7.body;
       expect(updatedBox1.contents).to.eql(_.map([res4.body[1], res4.body[3]], 'created'));
@@ -345,14 +345,14 @@ describe('PokemonController', () => {
     let publicId, privateId, viewableId;
     before(async () => {
       [publicId, privateId, viewableId] = await Promise.map(['public', 'private', 'viewable'], v =>
-        agent.post('/uploadpk6')
+        agent.post('/api/v1/pokemon')
           .field('visibility', v)
           .field('box', generalPurposeBox)
           .attach('pk6', __dirname + '/pkmn1.pk6')
       ).map(response => response.body.id);
     });
     it('allows third parties to view all the data on a public pokemon', async () => {
-      const res = await otherAgent.get(`/p/${publicId}`);
+      const res = await otherAgent.get(`/api/v1/pokemon/${publicId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.pid).to.exist();
       expect(res.body.encryptionConstant).to.exist();
@@ -364,7 +364,7 @@ describe('PokemonController', () => {
       expect(res.body.privateNotes).to.not.exist();
     });
     it('allows the uploader to view all the data on a viewable pokemon', async () => {
-      const res = await agent.get(`/p/${viewableId}`);
+      const res = await agent.get(`/api/v1/pokemon/${viewableId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.pid).to.exist();
       expect(res.body.speciesName).to.exist();
@@ -373,7 +373,7 @@ describe('PokemonController', () => {
       expect(res.body.publicNotes).to.exist();
     });
     it('allows third parties to view only public data on a viewable pokemon', async () => {
-      const res = await otherAgent.get(`/p/${viewableId}`);
+      const res = await otherAgent.get(`/api/v1/pokemon/${viewableId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist();
       expect(res.body.pid).to.not.exist();
@@ -387,7 +387,7 @@ describe('PokemonController', () => {
       expect(res.body.publicNotes).to.exist();
     });
     it('allows the uploader to view all the data on a private pokemon', async () => {
-      const res = await agent.get(`/p/${privateId}`);
+      const res = await agent.get(`/api/v1/pokemon/${privateId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.pid).to.exist();
       expect(res.body.speciesName).to.exist();
@@ -396,11 +396,11 @@ describe('PokemonController', () => {
       expect(res.body.publicNotes).to.exist();
     });
     it('does not allow third parties to view a private pokemon', async () => {
-      const res = await otherAgent.get(`/p/${privateId}`);
+      const res = await otherAgent.get(`/api/v1/pokemon/${privateId}`);
       expect(res.statusCode).to.equal(403);
     });
     it('allows an admin to view all the data on a public pokemon', async () => {
-      const res = await adminAgent.get(`/p/${publicId}`);
+      const res = await adminAgent.get(`/api/v1/pokemon/${publicId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist();
       expect(res.body.pid).to.exist();
@@ -409,7 +409,7 @@ describe('PokemonController', () => {
       expect(res.body.privateNotes).to.exist();
     });
     it('allows an admin to view all the data on a viewable pokemon', async () => {
-      const res = await adminAgent.get(`/p/${viewableId}`);
+      const res = await adminAgent.get(`/api/v1/pokemon/${viewableId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist();
       expect(res.body.pid).to.exist();
@@ -418,7 +418,7 @@ describe('PokemonController', () => {
       expect(res.body.privateNotes).to.exist();
     });
     it('allows an admin to view all the data on a private pokemon', async () => {
-      const res = await adminAgent.get(`/p/${privateId}`);
+      const res = await adminAgent.get(`/api/v1/pokemon/${privateId}`);
       expect(res.statusCode).to.equal(200);
       expect(res.body.dexNo).to.exist();
       expect(res.body.pid).to.exist();
@@ -427,28 +427,32 @@ describe('PokemonController', () => {
       expect(res.body.privateNotes).to.exist();
     });
     it('does not leak internal properties of a a pokemon to the client', async () => {
-      const pkmn = (await agent.get(`/pokemon/${publicId}`)).body;
+      const pkmn = (await agent.get(`/api/v1/pokemon/${publicId}`)).body;
       expect(pkmn._markedForDeletion).to.not.exist();
       expect(pkmn._rawPk6).to.not.exist();
     });
     it('allows a list of fields to be specified as a query parameter', async () => {
-      const res = await agent.get(`/p/${viewableId}`).query({pokemonFields: 'id,visibility,ivHp'});
+      const res = await agent.get(`/api/v1/pokemon/${viewableId}`).query({
+        pokemonFields: 'id,visibility,ivHp'
+      });
       expect(res.statusCode).to.equal(200);
       expect(res.body).to.eql({id: viewableId, visibility: 'viewable', ivHp: 31});
     });
     it('does not allow private fields to be sent even if specified in the query', async () => {
-      const res = await otherAgent.get(`/p/${viewableId}`).query({pokemonFields: 'id,pid'});
+      const res = await otherAgent.get(`/api/v1/pokemon/${viewableId}`)
+        .query({pokemonFields: 'id,pid'});
       expect(res.statusCode).to.equal(200);
       expect(res.body).to.eql({id: viewableId});
       expect(res.body.pid).not.to.exist();
     });
     it('allows private fields to be sent to the owner if specified in the query', async () => {
-      const res = await agent.get(`/p/${viewableId}`).query({pokemonFields: 'pid'});
+      const res = await agent.get(`/api/v1/pokemon/${viewableId}`).query({pokemonFields: 'pid'});
       expect(res.statusCode).to.equal(200);
       expect(Object.keys(res.body)).to.eql(['pid']);
     });
     it('does not leak internal properties of a pokemon if specified in the query', async () => {
-      const res = await agent.get(`/p/${viewableId}`).query({pokemonFields: '_rawPk6'});
+      const res = await agent.get(`/api/v1/pokemon/${viewableId}`)
+        .query({pokemonFields: '_rawPk6'});
       expect(res.statusCode).to.equal(200);
       expect(res.body).to.eql({});
     });
@@ -463,86 +467,88 @@ describe('PokemonController', () => {
       sails.services.constants.POKEMON_DELETION_DELAY = 2000;
     });
     beforeEach(async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .field('box', generalPurposeBox)
         .attach('pk6', `${__dirname}/pkmn1.pk6`);
       expect(res.statusCode).to.equal(201);
       pkmn = res.body;
     });
     it('allows the owner of a pokemon to delete it', async () => {
-      const res = await agent.del(`/p/${pkmn.id}`);
+      const res = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(404);
     });
     it("does not allow a third party to delete someone else's pokemon", async () => {
-      const res = await otherAgent.del(`/p/${pkmn.id}`);
+      const res = await otherAgent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(403);
-      const res2 = await otherAgent.get(`/p/${pkmn.id}`);
+      const res2 = await otherAgent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.not.equal(404);
     });
     it("allows an admin to delete someone's pokemon", async () => {
-      const res = await adminAgent.del(`/p/${pkmn.id}`);
+      const res = await adminAgent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(202);
-      expect((await agent.get(`/p/${pkmn.id}`)).statusCode).to.equal(404);
+      expect((await agent.get(`/api/v1/pokemon/${pkmn.id}`)).statusCode).to.equal(404);
     });
     it("allows an admin to undelete someone's pokemon", async () => {
-      const res = await agent.del(`/p/${pkmn.id}`);
+      const res = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await adminAgent.post(`/p/${pkmn.id}/undelete`);
+      const res2 = await adminAgent.post(`/api/v1/pokemon/${pkmn.id}/undelete`);
       expect(res2.statusCode).to.equal(200);
-      expect((await agent.get(`/p/${pkmn.id}`)).statusCode).to.equal(200);
+      expect((await agent.get(`/api/v1/pokemon/${pkmn.id}`)).statusCode).to.equal(200);
     });
     it('allows a deleted pokemon to be undeleted shortly afterwards', async () => {
-      await agent.del(`/p/${pkmn.id}`);
-      expect((await agent.get(`/p/${pkmn.id}`)).statusCode).to.equal(404);
-      const res = await agent.post(`/p/${pkmn.id}/undelete`);
+      await agent.del(`/api/v1/pokemon/${pkmn.id}`);
+      expect((await agent.get(`/api/v1/pokemon/${pkmn.id}`)).statusCode).to.equal(404);
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/undelete`);
       expect(res.statusCode).to.equal(200);
-      expect((await agent.get(`/p/${pkmn.id}`)).statusCode).to.equal(200);
+      expect((await agent.get(`/api/v1/pokemon/${pkmn.id}`)).statusCode).to.equal(200);
       await Promise.delay(sails.services.constants.POKEMON_DELETION_DELAY);
-      expect((await agent.get(`/p/${pkmn.id}`)).statusCode).to.equal(200);
+      expect((await agent.get(`/api/v1/pokemon/${pkmn.id}`)).statusCode).to.equal(200);
     });
     it('does not allow a pokemon to be undeleted once some time has elapsed', async () => {
-      await agent.del(`/p/${pkmn.id}`);
+      await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       await Promise.delay(sails.services.constants.POKEMON_DELETION_DELAY);
-      const res = await agent.post(`/p/${pkmn.id}/undelete`);
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/undelete`);
       expect(res.statusCode).to.equal(404);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(404);
     });
     it("does not allow a third party to undelete someone else's pokemon", async () => {
-      await agent.del(`/p/${pkmn.id}`);
-      expect((await otherAgent.post(`/p/${pkmn.id}/undelete`)).statusCode).to.equal(404);
+      await agent.del(`/api/v1/pokemon/${pkmn.id}`);
+      expect(
+        (await otherAgent.post(`/api/v1/pokemon/${pkmn.id}/undelete`)).statusCode
+      ).to.equal(404);
     });
     it('deletes a pokemon immediately if the `immediately` parameter is set to true', async () => {
-      await agent.del(`/p/${pkmn.id}`).send({immediately: true});
-      const res = await agent.post(`/p/${pkmn.id}/undelete`);
+      await agent.del(`/api/v1/pokemon/${pkmn.id}`).send({immediately: true});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/undelete`);
       expect(res.statusCode).to.equal(404);
     });
     it('does not hang the server while waiting for a pokemon to be fully deleted', async () => {
-      await agent.del(`/p/${pkmn.id}`);
+      await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       const timer = Promise.delay(sails.services.constants.POKEMON_DELETION_DELAY);
-      await agent.get('/');
+      await agent.get('/api/v1/');
       expect(timer.isFulfilled()).to.be.false();
     });
     it('does not show deleted contents when a box is retrieved', async () => {
-      const res = await agent.get(`/b/${pkmn.box}`);
-      const res2 = await agent.get(`/b/${pkmn.box}`).query({page: 2});
+      const res = await agent.get(`/api/v1/box/${pkmn.box}`);
+      const res2 = await agent.get(`/api/v1/box/${pkmn.box}`).query({page: 2});
       expect(_.map(res.body.contents.concat(res2.body.contents), 'id')).to.include(pkmn.id);
-      await agent.del(`/p/${pkmn.id}`);
-      const res3 = await agent.get(`/b/${pkmn.box}`);
-      const res4 = await agent.get(`/b/${pkmn.box}`).query({page: 2});
+      await agent.del(`/api/v1/pokemon/${pkmn.id}`);
+      const res3 = await agent.get(`/api/v1/box/${pkmn.box}`);
+      const res4 = await agent.get(`/api/v1/box/${pkmn.box}`).query({page: 2});
       expect(_.map(res3.body.contents.concat(res4.body.contents), 'id')).to.not.include(pkmn.id);
     });
     it('does not cause errors if the same Pokémon is deleted in two requests', async () => {
-      const res = await agent.del(`/p/${pkmn.id}`);
+      const res = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.post(`/p/${pkmn.id}/undelete`);
+      const res2 = await agent.post(`/api/v1/pokemon/${pkmn.id}/undelete`);
       expect(res2.statusCode).to.equal(200);
-      const res3 = await agent.del(`/p/${pkmn.id}`);
+      const res3 = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res3.statusCode).to.equal(202);
       await Promise.delay(sails.services.constants.POKEMON_DELETION_DELAY);
-      const res4 = await agent.get(`/p/${pkmn.id}`);
+      const res4 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res4.statusCode).to.equal(404);
     });
     after(() => {
@@ -552,18 +558,18 @@ describe('PokemonController', () => {
   describe('downloading a pokemon', () => {
     let publicPkmn, viewablePkmn, privatePkmn, rawPk6;
     before(async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('visibility', 'public')
         .field('box', generalPurposeBox);
       expect(res.statusCode).to.equal(201);
       publicPkmn = res.body;
-      const res2 = await agent.post('/uploadpk6')
+      const res2 = await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', generalPurposeBox);
       expect(res2.statusCode).to.equal(201);
       viewablePkmn = res2.body;
-      const res3 = await agent.post('/uploadpk6')
+      const res3 = await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('visibility', 'private')
         .field('box', generalPurposeBox);
@@ -572,85 +578,97 @@ describe('PokemonController', () => {
       rawPk6 = require('fs').readFileSync(`${__dirname}/pkmn1.pk6`).toString('utf8');
     });
     it('allows a user to download their own pokemon, regardless of visibility', async () => {
-      const res = await agent.get(`/p/${publicPkmn.id}/download`).buffer()
+      const res = await agent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer()
         .expect(
           'Content-Disposition',
           `attachment; filename=${publicPkmn.nickname}-${publicPkmn.id}.pk6`
         );
       expect(res.statusCode).to.equal(200);
       expect(res.text).to.equal(rawPk6);
-      const res2 = await agent.get(`/p/${viewablePkmn.id}/download`).buffer();
+      const res2 = await agent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(200);
       expect(res2.text).to.equal(rawPk6);
-      const res3 = await agent.get(`/p/${privatePkmn.id}/download`).buffer();
+      const res3 = await agent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(200);
       expect(res3.text).to.equal(rawPk6);
     });
     it("only allows other users to download someone's public pokemon", async () => {
-      const res = await otherAgent.get(`/p/${publicPkmn.id}/download`).buffer();
+      const res = await otherAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       expect(res.statusCode).to.equal(200);
       expect(res.text).to.equal(rawPk6);
-      const res2 = await otherAgent.get(`/p/${viewablePkmn.id}/download`).buffer();
+      const res2 = await otherAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(403);
       expect(res2.text).to.not.equal(rawPk6);
-      const res3 = await otherAgent.get(`/p/${privatePkmn.id}/download`).buffer();
+      const res3 = await otherAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(403);
       expect(res3.text).to.not.equal(rawPk6);
     });
     it('only allows an unauthenticated user to download a public pokemon', async () => {
-      const res = await noAuthAgent.get(`/p/${publicPkmn.id}/download`).buffer();
+      const res = await noAuthAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       expect(res.statusCode).to.equal(200);
       expect(res.text).to.equal(rawPk6);
-      const res2 = await noAuthAgent.get(`/p/${viewablePkmn.id}/download`).buffer();
+      const res2 = await noAuthAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(403);
       expect(res2.text).to.not.equal(rawPk6);
-      const res3 = await noAuthAgent.get(`/p/${privatePkmn.id}/download`).buffer();
+      const res3 = await noAuthAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(403);
       expect(res3.text).to.not.equal(rawPk6);
     });
     it('allows an admin to download any pokemon, regardless of visibility', async () => {
-      const res = await adminAgent.get(`/p/${publicPkmn.id}/download`).buffer();
+      const res = await adminAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       expect(res.statusCode).to.equal(200);
       expect(res.text).to.equal(rawPk6);
-      const res2 = await adminAgent.get(`/p/${viewablePkmn.id}/download`).buffer();
+      const res2 = await adminAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(200);
       expect(res2.text).to.equal(rawPk6);
-      const res3 = await adminAgent.get(`/p/${privatePkmn.id}/download`).buffer();
+      const res3 = await adminAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(200);
       expect(res3.text).to.equal(rawPk6);
     });
     it('increases the download count with downloads by third parties', async () => {
-      const initialCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
-      await otherAgent.get(`/p/${publicPkmn.id}/download`).buffer();
+      const initialCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;
+      await otherAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       await Promise.delay(500);
-      const newCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
+      const newCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;
       expect(newCount).to.equal(initialCount + 1);
     });
     it('increases the download count with downloads by unauthenticated users', async () => {
-      const initialCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
-      await noAuthAgent.get(`/p/${publicPkmn.id}/download`).buffer();
+      const initialCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;
+      await noAuthAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       await Promise.delay(500);
-      const newCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
+      const newCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;
       expect(newCount).to.equal(initialCount + 1);
     });
     it("does not increase the download count with downloads by a pokemon's owner", async () => {
-      const initialCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
-      await agent.get(`/p/${publicPkmn.id}/download`).buffer();
+      const initialCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;
+      await agent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       await Promise.delay(500);
-      const newCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
+      const newCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;
       expect(newCount).to.equal(initialCount);
     });
     it('increases the download count on admin downloads, only for public pokemon', async () => {
-      const initialPublicCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
-      const initialviewableCount = (await agent.get(`/p/${viewablePkmn.id}`)).body.downloadCount;
-      const initialPrivateCount = (await agent.get(`/p/${privatePkmn.id}`)).body.downloadCount;
-      await adminAgent.get(`/p/${publicPkmn.id}/download`).buffer();
-      await adminAgent.get(`/p/${viewablePkmn.id}/download`).buffer();
-      await adminAgent.get(`/p/${privatePkmn.id}/download`).buffer();
+      const initialPublicCount = (
+        await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)
+      ).body.downloadCount;
+      const initialviewableCount = (
+        await agent.get(`/api/v1/pokemon/${viewablePkmn.id}`)
+      ).body.downloadCount;
+      const initialPrivateCount = (
+        await agent.get(`/api/v1/pokemon/${privatePkmn.id}`)
+      ).body.downloadCount;
+      await adminAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
+      await adminAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
+      await adminAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       await Promise.delay(500);
-      const finalPublicCount = (await agent.get(`/p/${publicPkmn.id}`)).body.downloadCount;
-      const finalviewableCount = (await agent.get(`/p/${viewablePkmn.id}`)).body.downloadCount;
-      const finalPrivateCount = (await agent.get(`/p/${privatePkmn.id}`)).body.downloadCount;
+      const finalPublicCount = (
+        await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)
+      ).body.downloadCount;
+      const finalviewableCount = (
+        await agent.get(`/api/v1/pokemon/${viewablePkmn.id}`)
+      ).body.downloadCount;
+      const finalPrivateCount = (
+        await agent.get(`/api/v1/pokemon/${privatePkmn.id}`)
+      ).body.downloadCount;
       expect(finalPublicCount).to.equal(initialPublicCount + 1);
       expect(finalviewableCount).to.equal(initialviewableCount);
       expect(finalPrivateCount).to.equal(initialPrivateCount);
@@ -662,160 +680,179 @@ describe('PokemonController', () => {
     // pkmn, pkmn2, and pkmn3 start out in box1
     // pkmn4, pkmn5, and pkmn6 start out in box2
     beforeEach(async () => {
-      box1 = (await agent.post('/box').send({name: 'Shoebox'})).body;
-      box2 = (await agent.post('/box').send({name: 'Lunchbox'})).body;
-      pkmn = (await agent.post('/uploadpk6')
+      box1 = (await agent.post('/api/v1/box').send({name: 'Shoebox'})).body;
+      box2 = (await agent.post('/api/v1/box').send({name: 'Lunchbox'})).body;
+      pkmn = (await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', box1.id)).body;
-      pkmn2 = (await agent.post('/uploadpk6')
+      pkmn2 = (await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', box1.id)).body;
-      pkmn3 = (await agent.post('/uploadpk6')
+      pkmn3 = (await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', box1.id)).body;
-      pkmn4 = (await agent.post('/uploadpk6')
+      pkmn4 = (await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', box2.id)).body;
-      pkmn5 = (await agent.post('/uploadpk6')
+      pkmn5 = (await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', box2.id)).body;
-      pkmn6 = (await agent.post('/uploadpk6')
+      pkmn6 = (await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', box2.id)).body;
-      someoneElsesBox = (await otherAgent.post('/box').send({name: 'Mailbox'})).body;
-      someoneElsesPkmn = (await otherAgent.post('/uploadpk6')
+      someoneElsesBox = (await otherAgent.post('/api/v1/box').send({name: 'Mailbox'})).body;
+      someoneElsesPkmn = (await otherAgent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', someoneElsesBox.id)).body;
-      adminBox = (await adminAgent.post('/box').send({name: 'Icebox'})).body;
-      adminPkmn = (await adminAgent.post('/uploadpk6')
+      adminBox = (await adminAgent.post('/api/v1/box').send({name: 'Icebox'})).body;
+      adminPkmn = (await adminAgent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('box', adminBox.id)).body;
     });
     it('allows a user to move their own pokemon to a different box', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/move`).send({box: box2.id});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: box2.id});
       expect(res.statusCode).to.equal(200);
-      expect((await agent.get(`/p/${pkmn.id}`)).body.box).to.equal(box2.id);
-      const updatedBox1 = (await agent.get(`/b/${box1.id}`)).body;
+      expect((await agent.get(`/api/v1/pokemon/${pkmn.id}`)).body.box).to.equal(box2.id);
+      const updatedBox1 = (await agent.get(`/api/v1/box/${box1.id}`)).body;
       expect(_.map(updatedBox1.contents, 'id')).to.eql([pkmn2.id, pkmn3.id]);
-      const updatedBox2 = (await agent.get(`/b/${box2.id}`)).body;
+      const updatedBox2 = (await agent.get(`/api/v1/box/${box2.id}`)).body;
       expect(_.map(updatedBox2.contents, 'id')).to.eql([pkmn4.id, pkmn5.id, pkmn6.id, pkmn.id]);
       expect(+new Date(updatedBox2.updatedAt)).to.be.above(+new Date(box2.updatedAt));
     });
     it('allows an index to be specified for the pokemon within the new box', async () => {
-      const res = await agent.post(`/p/${pkmn2.id}/move`).send({box: box2.id, index: 1});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn2.id}/move`)
+        .send({box: box2.id, index: 1});
       expect(res.statusCode).to.equal(200);
-      expect((await agent.get(`/p/${pkmn2.id}`)).body.box).to.equal(box2.id);
-      const updatedBox1 = (await agent.get(`/b/${box1.id}`)).body;
+      expect((await agent.get(`/api/v1/pokemon/${pkmn2.id}`)).body.box).to.equal(box2.id);
+      const updatedBox1 = (await agent.get(`/api/v1/box/${box1.id}`)).body;
       expect(_.map(updatedBox1.contents, 'id')).to.eql([pkmn.id, pkmn3.id]);
-      const updatedBox2 = (await agent.get(`/b/${box2.id}`)).body;
+      const updatedBox2 = (await agent.get(`/api/v1/box/${box2.id}`)).body;
       expect(_.map(updatedBox2.contents, 'id')).to.eql([pkmn4.id, pkmn2.id, pkmn5.id, pkmn6.id]);
     });
     it('allows a pokemon to be relocated within its original box', async () => {
-      const res = await agent.post(`/p/${pkmn3.id}/move`).send({box: box1.id, index: 1});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn3.id}/move`)
+        .send({box: box1.id, index: 1});
       expect(res.statusCode).to.equal(200);
-      const updatedBox1 = (await agent.get(`/b/${box1.id}`)).body;
+      const updatedBox1 = (await agent.get(`/api/v1/box/${box1.id}`)).body;
       expect(_.map(updatedBox1.contents, 'id')).to.eql([pkmn.id, pkmn3.id, pkmn2.id]);
     });
     it('allows a pokemon to be moved to a later slot in its own box', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/move`).send({box: box1.id, index: 1});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: box1.id, index: 1});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box1.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmn2.id, pkmn.id, pkmn3.id]);
 
-      const res3 = await agent.post(`/p/${pkmn.id}/move`).send({box: box1.id, index: 2});
+      const res3 = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: box1.id, index: 2});
       expect(res3.statusCode).to.equal(200);
-      const res4 = await agent.get(`/b/${box1.id}`);
+      const res4 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res4.statusCode).to.equal(200);
       expect(_.map(res4.body.contents, 'id')).to.eql([pkmn2.id, pkmn3.id, pkmn.id]);
     });
     it('defaults to the last slot of the box if an index is not provided', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/move`).send({box: box1.id});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: box1.id});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box1.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmn2.id, pkmn3.id, pkmn.id]);
     });
     it('returns a 400 error if the length is out of range due to offsetting', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/move`).send({box: box1.id, index: 3});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: box1.id, index: 3});
       expect(res.statusCode).to.equal(400);
-      const res2 = await agent.get(`/b/${box1.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmn.id, pkmn2.id, pkmn3.id]);
     });
     it('allows index to equal the box length if the pkmn is moved to a different box', async () => {
-      const res = await agent.post(`/p/${pkmn4.id}/move`).send({box: box1.id, index: 3});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn4.id}/move`)
+        .send({box: box1.id, index: 3});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box1.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmn.id, pkmn2.id, pkmn3.id, pkmn4.id]);
     });
     it('does not take deleted IDs into account when moving by index', async () => {
-      const res = await agent.del(`/p/${pkmn2.id}`);
+      const res = await agent.del(`/api/v1/pokemon/${pkmn2.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.get(`/b/${box1.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmn.id, pkmn3.id]);
-      const res3 = await agent.post(`/p/${pkmn.id}/move`).send({box: box1.id, index: 1});
+      const res3 = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: box1.id, index: 1});
       expect(res3.statusCode).to.equal(200);
-      const res4 = await agent.get(`/b/${box1.id}`);
+      const res4 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res4.statusCode).to.equal(200);
       expect(_.map(res4.body.contents, 'id')).to.eql([pkmn3.id, pkmn.id]);
     });
     it('returns a 400 error if the provided index is too large due to deletion', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/move`).send({box: box1.id, index: 2});
+      const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: box1.id, index: 2});
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/b/${box1.id}`);
+      const res2 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(_.map(res2.body.contents, 'id')).to.eql([pkmn2.id, pkmn3.id, pkmn.id]);
-      const res3 = await agent.del(`/p/${pkmn.id}`);
+      const res3 = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res3.statusCode).to.equal(202);
-      const res4 = await agent.get(`/b/${box1.id}`);
+      const res4 = await agent.get(`/api/v1/box/${box1.id}`);
       expect(res4.statusCode).to.equal(200);
       expect(_.map(res4.body.contents, 'id')).to.eql([pkmn2.id, pkmn3.id]);
-      const res5 = await agent.post(`/p/${pkmn2.id}/move`).send({box: box1.id, index: 2});
+      const res5 = await agent.post(`/api/v1/pokemon/${pkmn2.id}/move`)
+        .send({box: box1.id, index: 2});
       expect(res5.statusCode).to.equal(400);
     });
     it("does not allow a third party to move someone's else pokemon", async () => {
-      const res = await otherAgent.post(`/p/${pkmn.id}/move`).send({box: someoneElsesBox.id});
+      const res = await otherAgent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: someoneElsesBox.id});
       expect(res.statusCode).to.equal(403);
-      const res2 = await otherAgent.post(`/p/${pkmn.id}/move`).send({box: box2.id});
+      const res2 = await otherAgent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: box2.id});
       expect(res2.statusCode).to.equal(403);
     });
     it("does not allow a third party to move their pokemon into someone else's box", async () => {
-      const res = await otherAgent.post(`/p/${someoneElsesPkmn.id}/move`).send({box: box1.id});
+      const res = await otherAgent.post(`/api/v1/pokemon/${someoneElsesPkmn.id}/move`).send({
+        box: box1.id
+      });
       expect(res.statusCode).to.equal(403);
     });
     it("allows an admin to move someone else's pokemon to another one of their boxes", async () => {
-      const res = await adminAgent.post(`/p/${pkmn.id}/move`).send({box: box2.id, index: 0});
+      const res = await adminAgent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: box2.id, index: 0});
       expect(res.statusCode).to.equal(200);
-      const updatedBox1 = (await agent.get(`/b/${box1.id}`)).body;
-      const updatedBox2 = (await agent.get(`/b/${box2.id}`)).body;
+      const updatedBox1 = (await agent.get(`/api/v1/box/${box1.id}`)).body;
+      const updatedBox2 = (await agent.get(`/api/v1/box/${box2.id}`)).body;
       expect(_.map(updatedBox1.contents, 'id')).to.eql([pkmn2.id, pkmn3.id]);
       expect(_.map(updatedBox2.contents, 'id')).to.eql([pkmn.id, pkmn4.id, pkmn5.id, pkmn6.id]);
-      const updatedPkmn = (await agent.get(`/p/${pkmn.id}`)).body;
+      const updatedPkmn = (await agent.get(`/api/v1/pokemon/${pkmn.id}`)).body;
       expect(updatedPkmn.box).to.equal(box2.id);
     });
     it("does not allow an admin to move one user's pokemon to a different user's box", async () => {
-      const res = await adminAgent.post(`/p/${pkmn.id}/move`).send({box: someoneElsesBox.id});
+      const res = await adminAgent.post(`/api/v1/pokemon/${pkmn.id}/move`)
+        .send({box: someoneElsesBox.id});
       expect(res.statusCode).to.equal(403);
     });
     it("does not allow an admin to move their own pokemon to someone else's box", async () => {
-      const res = await adminAgent.post(`/p/${adminPkmn.id}/move`).send({box: box2.id});
+      const res = await adminAgent.post(`/api/v1/pokemon/${adminPkmn.id}/move`)
+        .send({box: box2.id});
       expect(res.statusCode).to.equal(403);
     });
     it("does not allow an admin to move someone else's pokemon into the admin's box", async () => {
-      const res = await adminAgent.post(`/p/${pkmn.id}/move`).send({box: adminBox.id});
+      const res = await adminAgent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: adminBox.id});
       expect(res.statusCode).to.equal(403);
     });
     it('returns a 404 error if an invalid pokemon ID is included', async () => {
-      expect((await agent.post('/p/aaa/move').send({box: box2.id})).statusCode).to.equal(404);
+      expect(
+        (await agent.post('/api/v1/pokemon/aaa/move').send({box: box2.id})).statusCode
+      ).to.equal(404);
     });
     it('returns a 404 error if an invalid box ID is included', async () => {
-      expect((await agent.post(`/p/${pkmn.id}/move`).send({box: 'a'})).statusCode).to.equal(404);
+      expect((
+        await agent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: 'a'})
+      ).statusCode).to.equal(404);
     });
     it('returns a 400 error if no box ID is included', async () => {
-      expect((await agent.post(`/p/${pkmn.id}/move`)).statusCode).to.equal(400);
+      expect((await agent.post(`/api/v1/pokemon/${pkmn.id}/move`)).statusCode).to.equal(400);
     });
     it('returns a 400 error if the provided index is invalid', () => {
       const invalidIndices = [
@@ -827,9 +864,9 @@ describe('PokemonController', () => {
         null // not an integer
       ];
       return Promise.each(invalidIndices, async index => {
-        const res = await agent.post(`/p/${pkmn.id}/move`).send({box: box2.id, index});
-        const res2 = await agent.get(`/b/${box1.id}`);
-        const res3 = await agent.get(`/b/${box2.id}`);
+        const res = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: box2.id, index});
+        const res2 = await agent.get(`/api/v1/box/${box1.id}`);
+        const res3 = await agent.get(`/api/v1/box/${box2.id}`);
         expect(res2.statusCode).to.equal(200);
         expect(res3.statusCode).to.equal(200);
         expect(_.map(res2.body.contents, 'id')).to.eql([pkmn.id, pkmn2.id, pkmn3.id]);
@@ -838,22 +875,22 @@ describe('PokemonController', () => {
       });
     });
     it("does not allow a pokemon to be moved if it's marked for deletion", async () => {
-      const res = await agent.del(`/p/${pkmn.id}`);
+      const res = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.post(`/p/${pkmn.id}/move`).send({box: box2.id});
+      const res2 = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: box2.id});
       expect(res2.statusCode).to.equal(404);
     });
     it("does not allow a pokemon to be moved to a box that's marked for deletion", async () => {
-      const res = await agent.del(`/b/${box2.id}`);
+      const res = await agent.del(`/api/v1/box/${box2.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.post(`/p/${pkmn.id}/move`).send({box: box2.id});
+      const res2 = await agent.post(`/api/v1/pokemon/${pkmn.id}/move`).send({box: box2.id});
       expect(res2.statusCode).to.equal(404);
     });
   });
   describe("editing a pokemon's visibility and notes", () => {
     let pkmn;
     beforeEach(async () => {
-      const res = await agent.post('/uploadpk6')
+      const res = await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pkmn1.pk6`)
         .field('visibility', 'viewable')
         .field('box', generalPurposeBox);
@@ -861,49 +898,51 @@ describe('PokemonController', () => {
       pkmn = res.body;
     });
     it("allows a user to edit their pokemon's visibility", async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({
         visibility: 'private',
         publicNotes: 'public things',
         privateNotes: 'private things'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.visibility).to.equal('private');
       expect(res2.body.publicNotes).to.equal('public things');
       expect(res2.body.privateNotes).to.equal('private things');
     });
     it('returns a 400 error if no valid parameters are specified', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({owner: 'AAAAA'});
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({owner: 'AAAAA'});
       expect(res.statusCode).to.equal(400);
     });
     it('returns a 404 error if given an invalid pokemon id', async () => {
-      const res = await agent.post('/p/invalidpokemonid/edit').send({visibility: 'private'});
+      const res = await agent.patch('/api/v1/pokemon/invalidpokemonid')
+        .send({visibility: 'private'});
       expect(res.statusCode).to.equal(404);
     });
     it("does not allow a user to edit another user's pokemon's visibility", async () => {
-      const res = await otherAgent.post(`/p/${pkmn.id}/edit`).send({visibility: 'private'});
+      const res = await otherAgent.patch(`/api/v1/pokemon/${pkmn.id}`)
+        .send({visibility: 'private'});
       expect(res.statusCode).to.equal(403);
     });
     it("allows an admin to edit a pokemon's info", async () => {
-      const res = await adminAgent.post(`/p/${pkmn.id}/edit`).send({
+      const res = await adminAgent.patch(`/api/v1/pokemon/${pkmn.id}`).send({
         visibility: 'private',
         publicNotes: 'foo'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.visibility).to.equal('private');
       expect(res2.body.publicNotes).to.equal('foo');
     });
     it('does not allow a deleted pokemon to be edited', async () => {
-      const res = await agent.del(`/p/${pkmn.id}`);
+      const res = await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       expect(res.statusCode).to.equal(202);
-      const res2 = await agent.post(`/p/${pkmn.id}/edit`).send({visibility: 'private'});
+      const res2 = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({visibility: 'private'});
       expect(res2.statusCode).to.equal(404);
     });
     it('returns a 400 error if the given visibility is invalid', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({
         visibility: 'foo',
         publicNotes: 'bar',
         privateNotes: 'baz'
@@ -912,41 +951,45 @@ describe('PokemonController', () => {
       expect(res.body).to.equal('Invalid Pokémon visibility');
     });
     it('returns a 400 error if the given public notes are too long', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({publicNotes: 'A'.repeat(3000)});
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({
+        publicNotes: 'A'.repeat(3000)
+      });
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Public notes too long');
     });
     it('returns a 400 error if the given private notes are too long', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({privateNotes: 'A'.repeat(3000)});
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({
+        privateNotes: 'A'.repeat(3000)
+      });
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Private notes too long');
     });
     it('returns a 400 error if the given public notes are invalid', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({publicNotes: 5});
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({publicNotes: 5});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Invalid publicNotes');
     });
     it('returns a 400 error if the given private notes are invalid', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({privateNotes: 5});
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({privateNotes: 5});
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.equal('Invalid privateNotes');
     });
     it('does not modify other fields if only some fields are specified', async () => {
-      const res = await agent.post(`/p/${pkmn.id}/edit`).send({
+      const res = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({
         visibility: 'private',
         publicNotes: 'foo',
         privateNotes: 'bar'
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get(`/p/${pkmn.id}`);
+      const res2 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.visibility).to.equal('private');
       expect(res2.body.publicNotes).to.equal('foo');
       expect(res2.body.privateNotes).to.equal('bar');
 
-      const res3 = await agent.post(`/p/${pkmn.id}/edit`).send({publicNotes: 'baz'});
+      const res3 = await agent.patch(`/api/v1/pokemon/${pkmn.id}`).send({publicNotes: 'baz'});
       expect(res3.statusCode).to.equal(200);
-      const res4 = await agent.get(`/p/${pkmn.id}`);
+      const res4 = await agent.get(`/api/v1/pokemon/${pkmn.id}`);
       expect(res4.statusCode).to.equal(200);
       expect(res4.body.visibility).to.equal('private');
       expect(res4.body.publicNotes).to.equal('baz');

--- a/test/controller/user.js
+++ b/test/controller/user.js
@@ -5,14 +5,14 @@ describe('UserController', () => {
   let agent, adminAgent, noAuthAgent, generalPurposeBox;
   before(async () => {
     agent = supertest.agent(sails.hooks.http.app);
-    const res = await agent.post('/auth/local/register').send({
+    const res = await agent.post('/api/v1/auth/local/register').send({
       name: 'usertester',
       password: '********',
       email: 'usertester@usertesting.com'
     });
     expect(res.statusCode).to.equal(200);
     adminAgent = supertest.agent(sails.hooks.http.app);
-    const res2 = await adminAgent.post('/auth/local/register').send({
+    const res2 = await adminAgent.post('/api/v1/auth/local/register').send({
       name: 'IM_AN_ADMIN_FEAR_ME',
       password: '***********************************************************************',
       email: 'admin@porybox.com'
@@ -21,18 +21,18 @@ describe('UserController', () => {
     await sails.models.user.update({name: 'IM_AN_ADMIN_FEAR_ME'}, {isAdmin: true});
     noAuthAgent = supertest.agent(sails.hooks.http.app);
 
-    const res3 = await agent.post('/box').send({name: 'Boxer'});
+    const res3 = await agent.post('/api/v1/box').send({name: 'Boxer'});
     expect(res3.statusCode).to.equal(201);
     generalPurposeBox = res3.body.id;
   });
   it('can redirect users to information about their own profile', async () => {
-    const res = await agent.get('/me');
+    const res = await agent.get('/api/v1/me');
     expect(res.statusCode).to.equal(302);
     expect(res.header.location).to.equal('/user/usertester');
   });
   describe('getting a user profile', () => {
     it('returns full information when a user gets their own profile', async () => {
-      const res = await agent.get('/user/usertester');
+      const res = await agent.get('/api/v1/user/usertester');
       expect(res.statusCode).to.equal(200);
       expect(res.body.name).to.equal('usertester');
       expect(res.body.isAdmin).to.be.false();
@@ -49,7 +49,7 @@ describe('UserController', () => {
       expect(res.body.preferences.id).to.not.exist();
     });
     it("omits private information when a user gets someone else's profile", async () => {
-      const res = await agent.get('/user/IM_AN_ADMIN_FEAR_ME');
+      const res = await agent.get('/api/v1/user/IM_AN_ADMIN_FEAR_ME');
       expect(res.statusCode).to.equal(200);
       expect(res.body.name).to.equal('IM_AN_ADMIN_FEAR_ME');
       expect(res.body.isAdmin).to.be.true();
@@ -63,7 +63,7 @@ describe('UserController', () => {
       expect(res.body.passports).not.to.exist();
     });
     it("returns full information when an admin gets someone else's profile", async () => {
-      const res = await adminAgent.get('/user/usertester');
+      const res = await adminAgent.get('/api/v1/user/usertester');
       expect(res.statusCode).to.equal(200);
       expect(res.body.name).to.equal('usertester');
       expect(res.body.isAdmin).to.be.false();
@@ -74,7 +74,7 @@ describe('UserController', () => {
       expect(res.body.trainerShinyValues).exist();
     });
     it('omits private information when an unauthenticated user gets a profile', async () => {
-      const res = await noAuthAgent.get('/user/usertester');
+      const res = await noAuthAgent.get('/api/v1/user/usertester');
       expect(res.statusCode).to.equal(200);
       expect(res.body.name).to.equal('usertester');
       expect(res.body.isAdmin).to.be.false();
@@ -85,61 +85,62 @@ describe('UserController', () => {
       expect(res.body.trainerShinyValues).exist();
     });
     it('omits server-only properties when anyone gets the profile', async () => {
-      const res = await agent.get('/user/usertester');
+      const res = await agent.get('/api/v1/user/usertester');
       expect(res.statusCode).to.equal(200);
       expect(res.body._orderedBoxIds).to.not.exist();
-      const res2 = await adminAgent.get('/user/usertester');
+      const res2 = await adminAgent.get('/api/v1/user/usertester');
       expect(res2.statusCode).to.equal(200);
       expect(res2.body._orderedBoxIds).to.not.exist();
-      const res3 = await noAuthAgent.get('/user/usertester');
+      const res3 = await noAuthAgent.get('/api/v1/user/usertester');
       expect(res3.statusCode).to.equal(200);
       expect(res3.body._orderedBoxIds).to.not.exist();
     });
   });
   describe('preferences', () => {
     it("can get a user's preferences", async () => {
-      const res = await agent.get('/preferences');
+      const res = await agent.get('/api/v1/me/preferences');
       expect(res.body.defaultBoxVisibility).to.equal('listed');
       expect(res.body.defaultPokemonVisibility).to.equal('viewable');
     });
     describe('modifying preferences', () => {
       it("can edit a user's preferences", async () => {
-        await agent.post('/preferences/edit').send({defaultBoxVisibility: 'unlisted'});
-        const newPrefs = (await agent.get('/preferences')).body;
+        await agent.patch('/api/v1/me/preferences').send({defaultBoxVisibility: 'unlisted'});
+        const newPrefs = (await agent.get('/api/v1/me/preferences')).body;
         expect(newPrefs.defaultBoxVisibility).to.equal('unlisted');
-        await agent.post('/preferences/edit').send({defaultBoxVisibility: 'listed'});
-        const revertedPrefs = (await agent.get('/preferences')).body;
+        await agent.patch('/api/v1/me/preferences').send({defaultBoxVisibility: 'listed'});
+        const revertedPrefs = (await agent.get('/api/v1/me/preferences')).body;
         expect(revertedPrefs.defaultBoxVisibility).to.equal('listed');
       });
       it('only allows users to change certain preference attributes', async () => {
         /* i.e. even though `user` is an attribute in the UserPreferences schema, the server
         shouldn't allow the user to change it. */
-        const res = await agent.post('/preferences/edit').send({user: 'someone_else'});
+        const res = await agent.patch('/api/v1/me/preferences').send({user: 'someone_else'});
         expect(res.statusCode).to.equal(400);
       });
       it('returns a 400 error when sent invalid preference values', async () => {
-        const res = await agent.post('/preferences/edit').send({defaultBoxVisibility: 'invalid'});
+        const res = await agent.patch('/api/v1/me/preferences')
+          .send({defaultBoxVisibility: 'invalid'});
         expect(res.statusCode).to.equal(400);
       });
     });
     describe('defaultBoxVisibility', () => {
       it('sets the default visibility of uploaded boxes', async () => {
-        await agent.post('/preferences/edit').send({defaultBoxVisibility: 'unlisted'});
-        const newBox = (await agent.post('/box').send({name: 'Lunchbox'})).body;
+        await agent.patch('/api/v1/me/preferences').send({defaultBoxVisibility: 'unlisted'});
+        const newBox = (await agent.post('/api/v1/box').send({name: 'Lunchbox'})).body;
         expect(newBox.visibility).to.equal('unlisted');
-        await agent.post('/preferences/edit').send({defaultBoxVisibility: 'listed'});
-        const evenNewerBox = (await agent.post('/box').send({name: 'Chatterbox'})).body;
+        await agent.patch('/api/v1/me/preferences').send({defaultBoxVisibility: 'listed'});
+        const evenNewerBox = (await agent.post('/api/v1/box').send({name: 'Chatterbox'})).body;
         expect(evenNewerBox.visibility).to.equal('listed');
       });
       it('can be overridden by specifying a visibility while uploading a box', async () => {
-        await agent.post('/preferences/edit').send({defaultBoxVisibility: 'unlisted'});
-        const newBox = (await agent.post('/box').send({
+        await agent.patch('/api/v1/me/preferences').send({defaultBoxVisibility: 'unlisted'});
+        const newBox = (await agent.post('/api/v1/box').send({
           name: 'Matchbox',
           visibility: 'listed'
         })).body;
         expect(newBox.visibility).to.equal('listed');
-        await agent.post('/preferences/edit').send({defaultBoxVisibility: 'listed'});
-        const evenNewerBox = (await agent.post('/box').send({
+        await agent.patch('/api/v1/me/preferences').send({defaultBoxVisibility: 'listed'});
+        const evenNewerBox = (await agent.post('/api/v1/box').send({
           name: 'Toolbox',
           visibility: 'unlisted'
         })).body;
@@ -148,29 +149,29 @@ describe('UserController', () => {
     });
     describe('defaultPokemonVisibility', () => {
       it('sets the default visibility of uploaded pokemon', async () => {
-        await agent.post('/preferences/edit').send({defaultPokemonVisibility: 'public'});
-        const res = await agent.post('/uploadpk6')
+        await agent.patch('/api/v1/me/preferences').send({defaultPokemonVisibility: 'public'});
+        const res = await agent.post('/api/v1/pokemon')
           .attach('pk6', `${__dirname}/pkmn1.pk6`)
           .field('box', generalPurposeBox);
         expect(res.statusCode).to.equal(201);
         expect(res.body.visibility).to.equal('public');
-        await agent.post('/preferences/edit').send({defaultPokemonVisibility: 'viewable'});
-        const res2 = await agent.post('/uploadpk6')
+        await agent.patch('/api/v1/me/preferences').send({defaultPokemonVisibility: 'viewable'});
+        const res2 = await agent.post('/api/v1/pokemon')
           .attach('pk6', `${__dirname}/pkmn1.pk6`)
           .field('box', generalPurposeBox);
         expect(res2.statusCode).to.equal(201);
         expect(res2.body.visibility).to.equal('viewable');
       });
       it('can be overridden by specifying a visibility while uploading a pokemon', async () => {
-        await agent.post('/preferences/edit').send({defaultPokemonVisibility: 'public'});
-        const res = await agent.post('/uploadpk6')
+        await agent.patch('/api/v1/me/preferences').send({defaultPokemonVisibility: 'public'});
+        const res = await agent.post('/api/v1/pokemon')
           .field('visibility', 'viewable')
           .field('box', generalPurposeBox)
           .attach('pk6', `${__dirname}/pkmn1.pk6`);
         expect(res.statusCode).to.equal(201);
         expect(res.body.visibility).to.equal('viewable');
-        await agent.post('/preferences/edit').send({defaultPokemonVisibility: 'viewable'});
-        const res2 = await agent.post('/uploadpk6')
+        await agent.patch('/api/v1/me/preferences').send({defaultPokemonVisibility: 'viewable'});
+        const res2 = await agent.post('/api/v1/pokemon')
           .field('visibility', 'public')
           .field('box', generalPurposeBox)
           .attach('pk6', `${__dirname}/pkmn1.pk6`);
@@ -181,7 +182,7 @@ describe('UserController', () => {
   });
   describe('editing account information', async () => {
     beforeEach(async () => {
-      const res = await agent.post('/me').send({
+      const res = await agent.patch('/api/v1/me').send({
         friendCodes: [],
         inGameNames: [],
         trainerShinyValues: []
@@ -189,24 +190,24 @@ describe('UserController', () => {
       expect(res.statusCode).to.equal(200);
     });
     it('allows a user to edit their account information', async () => {
-      const res = await agent.post('/me').send({
+      const res = await agent.patch('/api/v1/me').send({
         friendCodes: ['0000-0000-0000', '1111-1111-1111'],
         inGameNames: ['Joe', 'Steve', 'Bob'],
         trainerShinyValues: ['0000', '4095', '1337']
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get('/user/usertester');
+      const res2 = await agent.get('/api/v1/user/usertester');
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.friendCodes).to.eql(['0000-0000-0000', '1111-1111-1111']);
       expect(res2.body.inGameNames).to.eql(['Joe', 'Steve', 'Bob']);
       expect(res2.body.trainerShinyValues).to.eql(['0000', '4095', '1337']);
     });
     it('allows the user to edit a subset of their information by omitting parameters', async () => {
-      const res = await agent.post('/me').send({
+      const res = await agent.patch('/api/v1/me').send({
         friendCodes: ['0000-0000-0135']
       });
       expect(res.statusCode).to.equal(200);
-      const res2 = await agent.get('/user/usertester');
+      const res2 = await agent.get('/api/v1/user/usertester');
       expect(res2.statusCode).to.equal(200);
       expect(res2.body.friendCodes).to.eql(['0000-0000-0135']);
       expect(res2.body.inGameNames).to.eql([]);
@@ -238,8 +239,8 @@ describe('UserController', () => {
         {friendCodes: ['0123-4567-8901'], inGameNames: ['Joe'], trainerShinyValues: ['9999']}
       ];
       return Promise.each(invalidParameterSets, async params => {
-        const res = await agent.post('/me').send(params);
-        const res2 = await agent.get('/user/usertester');
+        const res = await agent.patch('/api/v1/me').send(params);
+        const res2 = await agent.get('/api/v1/user/usertester');
         expect(res2.body.friendCodes).to.eql([]);
         expect(res2.body.inGameNames).to.eql([]);
         expect(res2.body.trainerShinyValues).to.eql([]);
@@ -257,25 +258,25 @@ describe('UserController', () => {
       await sails.models.user.update({name: {not: 'IM_AN_ADMIN_FEAR_ME'}}, {isAdmin: false});
     });
     it('allows admins to grant/revoke admin status to other users', async () => {
-      const res = await adminAgent.post('/user/usertester/grantAdminStatus');
+      const res = await adminAgent.post('/api/v1/user/usertester/grantAdminStatus');
       expect(res.statusCode).to.equal(200);
-      expect((await noAuthAgent.get('/user/usertester')).body.isAdmin).to.be.true();
-      const res2 = await adminAgent.post('/user/usertester/revokeAdminStatus');
+      expect((await noAuthAgent.get('/api/v1/user/usertester')).body.isAdmin).to.be.true();
+      const res2 = await adminAgent.post('/api/v1/user/usertester/revokeAdminStatus');
       expect(res2.statusCode).to.equal(200);
-      expect((await noAuthAgent.get('/user/usertester')).body.isAdmin).to.be.false();
+      expect((await noAuthAgent.get('/api/v1/user/usertester')).body.isAdmin).to.be.false();
     });
     it('does not allow non-admins to grant/revoke admin status', async () => {
-      const res = await agent.post('/user/usertester/grantAdminStatus');
+      const res = await agent.post('/api/v1/user/usertester/grantAdminStatus');
       expect(res.statusCode).to.equal(403);
-      expect((await noAuthAgent.get('/user/usertester')).body.isAdmin).to.be.false();
-      const res2 = await agent.post('/user/IM_AN_ADMIN_FEAR_ME/revokeAdminStatus');
+      expect((await noAuthAgent.get('/api/v1/user/usertester')).body.isAdmin).to.be.false();
+      const res2 = await agent.post('/api/v1/user/IM_AN_ADMIN_FEAR_ME/revokeAdminStatus');
       expect(res2.statusCode).to.equal(403);
-      expect((await noAuthAgent.get('/user/IM_AN_ADMIN_FEAR_ME')).body.isAdmin).to.be.true();
+      expect((await noAuthAgent.get('/api/v1/user/IM_AN_ADMIN_FEAR_ME')).body.isAdmin).to.be.true();
     });
     it('returns a 404 error if the specified user does not exist', async () => {
-      const res = await adminAgent.post('/user/nonexistent_username/grantAdminStatus');
+      const res = await adminAgent.post('/api/v1/user/nonexistent_username/grantAdminStatus');
       expect(res.statusCode).to.equal(404);
-      const res2 = await adminAgent.post('/user/nonexistent_username/revokeAdminStatus');
+      const res2 = await adminAgent.post('/api/v1/user/nonexistent_username/revokeAdminStatus');
       expect(res2.statusCode).to.equal(404);
     });
   });
@@ -284,7 +285,7 @@ describe('UserController', () => {
     beforeEach(async () => {
       deleteAgent = supertest.agent(sails.hooks.http.app);
       const uniqueUsername = `deleteTester${require('crypto').randomBytes(4).toString('hex')}`;
-      const res = await deleteAgent.post('/auth/local/register').send({
+      const res = await deleteAgent.post('/api/v1/auth/local/register').send({
         name: uniqueUsername,
         password: 'correct-password',
         email: `${uniqueUsername}@usertesting.com`
@@ -292,20 +293,21 @@ describe('UserController', () => {
       expect(res.statusCode).to.equal(200);
     });
     it('allows an account to be deleted if the correct password is provided', async () => {
-      const res = await deleteAgent.post('/deleteAccount').send({password: 'correct-password'});
+      const res = await deleteAgent.del('/api/v1/me').send({password: 'correct-password'});
       expect(res.statusCode).to.equal(200);
     });
     it('does not allow an account to be deleted if an incorrect password is provided', async () => {
-      const res = await deleteAgent.post('/deleteAccount').send({password: 'incorrect-password'});
+      const res = await deleteAgent.del('/api/v1/me').send({password: 'incorrect-password'});
       expect(res.statusCode).to.equal(403);
     });
     it("deletes all of a user's boxes when their account is deleted", async () => {
-      const res = await deleteAgent.post('/box').send({name: 'My box', visibility: 'listed'});
+      const res = await deleteAgent.post('/api/v1/box')
+        .send({name: 'My box', visibility: 'listed'});
       expect(res.statusCode).to.equal(201);
       const box = res.body;
-      expect((await agent.get(`/b/${box.id}`)).statusCode).to.equal(200);
-      await deleteAgent.post('/deleteAccount').send({password: 'correct-password'});
-      expect((await agent.get(`/b/${box.id}`)).statusCode).to.equal(404);
+      expect((await agent.get(`/api/v1/box/${box.id}`)).statusCode).to.equal(200);
+      await deleteAgent.del('/api/v1/me').send({password: 'correct-password'});
+      expect((await agent.get(`/api/v1/box/${box.id}`)).statusCode).to.equal(404);
     });
   });
 });


### PR DESCRIPTION
fixes #194

This PR updates the server's API endpoints to be more RESTful, along with adding an `/api/v1` prefix to avoid route conflicts and allow future API changes. It also updates the client and the tests to match these endpoints.

I'm open to any other suggestions anyone might have about making endpoints more RESTful, but I thought we should change this sooner rather than later so that people can start relying on our API.

---

(same as #344 but onto master this time)