### PR TITLE
Use prototype functions for client controllers

### DIFF
--- a/client/add/box.ctrl.js
+++ b/client/add/box.ctrl.js
@@ -2,27 +2,28 @@
  * Controller for handling the dialog to add a new box
  * @return {function} A controller that contains 2 test elements
  */
-module.exports = function ($mdDialog) {
 
-  this.name = '';
-  this.description = '';
-  // TODO: Make this depend on the default user preferences
-  this.visibility = 'listed';
+module.exports = class BoxAdd {
+  constructor ($mdDialog) {
+    this.$mdDialog = $mdDialog;
 
-  this.cancel = function() {
-    $mdDialog.cancel();
-  };
-  this.canAdd = function () {
-    return Boolean(this.name);
-  };
-  this.answer = function() {
-    if (!this.name) {
-      return;
-    }
-    $mdDialog.hide({
+    this.name = '';
+    this.description = '';
+    // TODO: Make this depend on the default user preferences
+    this.visibility = 'listed';
+  }
+  cancel () {
+    this.$mdDialog.cancel();
+  }
+  canAdd () {
+    return !!this.name;
+  }
+  answer () {
+    if (!this.name) return;
+    this.$mdDialog.hide({
       name: this.name,
       description: this.description,
       visibility: this.visibility
     });
-  };
+  }
 };

--- a/client/add/pokemon.ctrl.js
+++ b/client/add/pokemon.ctrl.js
@@ -5,22 +5,28 @@ import Promise from 'bluebird';
  * Controller for handling the dialog to add a new pokemon
  * @return {function} A controller that contains 2 test elements
  */
-module.exports = function ($mdDialog, $routeParams) {
-  this.visibilities = require('../../api/services/Constants.js').POKEMON_VISIBILITIES;
-  this.defaultBox = undefined;
 
-  if (this.boxes.length) {
-    this.defaultBox =
-      $routeParams.boxid && this.boxes.map(box => box.id).includes($routeParams.boxid)
-        ? $routeParams.boxid
-        : maxBy(this.boxes, box => +new Date(box.updatedAt)).id;
+module.exports = class PokemonAdd {
+  constructor ($mdDialog, $routeParams) {
+    this.$mdDialog = $mdDialog;
+    this.$routeParams = $routeParams;
+
+    this.visibilities = require('../../api/services/Constants').POKEMON_VISIBILITIES;
+    this.defaultBox = undefined;
+    if (this.boxes.length) {
+      this.defaultBox =
+        this.$routeParams.boxid && this.boxes.map(box => box.id).includes(this.$routeParams.boxid)
+          ? this.$routeParams.boxid
+          : maxBy(this.boxes, box => +new Date(box.updatedAt)).id;
+    }
+    this.lines = [];
   }
 
-  this.lines = [];
+  addLine (line) {
+    this.lines.push(line);
+  }
 
-  this.addLine = (line) => this.lines.push(line);
-
-  this.addFiles = (files) => {
+  addFiles (files) {
     files.forEach(file => this.addLine({
       filename: file.name,
       data: fileToBase64(file),
@@ -29,19 +35,18 @@ module.exports = function ($mdDialog, $routeParams) {
     }));
     this.draggedFiles = [];
     this.manualFiles = [];
-  };
+  }
 
-  this.cancel = function() {
-    return $mdDialog.cancel();
-  };
+  cancel () {
+    return this.$mdDialog.cancel();
+  }
 
-  this.canAdd = function () {
+  canAdd () {
     return this.lines.every((line) => line.visibility && line.data && line.box);
-  };
-
-  this.answer = function() {
-    return $mdDialog.hide(this.lines);
-  };
+  }
+  answer () {
+    return this.$mdDialog.hide(this.lines);
+  }
 };
 
 function fileToBase64 (file) {

--- a/client/box/box-edit.ctrl.js
+++ b/client/box/box-edit.ctrl.js
@@ -2,26 +2,27 @@
  * Controller for handling the dialog to add a new box
  * @return {function} A controller that contains 2 test elements
  */
-module.exports = function ($mdDialog) {
 
-  this.name = this.data.name;
-  this.description = this.data.description;
-  this.visibility = this.data.visibility;
+module.exports = class BoxEdit {
+  constructor ($mdDialog) {
+    this.$mdDialog = $mdDialog;
 
-  this.cancel = function() {
-    $mdDialog.cancel();
-  };
-  this.canAdd = function () {
-    return Boolean(this.name);
-  };
-  this.answer = function() {
-    if (!this.name) {
-      return;
-    }
-    $mdDialog.hide({
+    this.name = this.data.name;
+    this.description = this.data.description;
+    this.visibility = this.data.visibility;
+  }
+  cancel () {
+    this.$mdDialog.cancel();
+  }
+  canAdd () {
+    return !!this.name;
+  }
+  answer () {
+    if (!this.name) return;
+    this.$mdDialog.hide({
       name: this.name,
       description: this.description,
       visibility: this.visibility
     });
-  };
+  }
 };

--- a/client/box/box.ctrl.js
+++ b/client/box/box.ctrl.js
@@ -35,20 +35,26 @@ const POKEMON_FIELDS_USED = [
   'visibility'
 ].join(',');
 
-module.exports = function(
-    $scope, $ngSilentLocation, $routeParams, io, $mdMedia, $mdDialog, errorHandler
-) {
-  this.data = this.data || {contents: []};
-  this.id = $routeParams.boxid || this.data.id;
-  this.selected = this.selected || ($scope.$parent.main ? $scope.$parent.main.selected : {});
-  this.selected.selectedBox = this.data;
-  this.errorStatusCode = null;
-  this.indexInMain = null;
-  this.isDeleted = false;
-  this.currentPageNum = +$routeParams.pageNum || this.data.pageNum || 1;
-
-  this.fetch = () => {
-    return io.socket.getAsync(`/api/v1/box/${this.id}`, {
+module.exports = class Box {
+  constructor($scope, $ngSilentLocation, $routeParams, io, $mdMedia, $mdDialog, errorHandler) {
+    this.$scope = $scope;
+    this.$ngSilentLocation = $ngSilentLocation;
+    this.$routeParams = $routeParams;
+    this.io = io;
+    this.$mdMedia = $mdMedia;
+    this.$mdDialog = $mdDialog;
+    this.errorHandler = errorHandler;
+    this.data = this.data || {contents: []};
+    this.id = $routeParams.boxid || this.data.id;
+    this.selected = this.selected || ($scope.$parent.main ? $scope.$parent.main.selected : {});
+    this.selected.selectedBox = this.data;
+    this.errorStatusCode = null;
+    this.indexInMain = null;
+    this.isDeleted = false;
+    this.currentPageNum = +$routeParams.pageNum || this.data.pageNum || 1;
+  }
+  fetch () {
+    return this.io.socket.getAsync(`/api/v1/box/${this.id}`, {
       pokemonFields: POKEMON_FIELDS_USED,
       page: this.currentPageNum
     }).then(data => {
@@ -56,38 +62,41 @@ module.exports = function(
       this.hasFullData = true;
     }).catch(err => {
       this.errorStatusCode = err.statusCode;
-    }).then(() => $scope.$apply());
-  };
-
-  this.isLoading = () => this.currentPageNum !== this.data.pageNum;
-  this.hasPrevPage = () => this.currentPageNum > 1;
-  this.hasNextPage = () => this.currentPageNum < this.data.totalPageCount;
-
-  this.prevPage = () => {
+    }).then(() => this.$scope.$apply());
+  }
+  isLoading () {
+    return this.currentPageNum !== this.data.pageNum;
+  }
+  hasPrevPage () {
+    return this.currentPageNum > 1;
+  }
+  hasNextPage () {
+    return this.currentPageNum < this.data.totalPageCount;
+  }
+  prevPage () {
     if (this.hasPrevPage()) {
       // Update the location hash without reloading the controller
       // Unfortunately it doesn't seem to be possible to do this natively with angular.
       // https://github.com/angular/angular.js/issues/1699
-      $ngSilentLocation.silent(`/box/${this.id}/${--this.currentPageNum}`);
+      this.$ngSilentLocation.silent(`/box/${this.id}/${--this.currentPageNum}`);
       return this.fetch();
     }
-  };
-
-  this.nextPage = () => {
+  }
+  nextPage () {
     if (this.hasNextPage()) {
-      $ngSilentLocation.silent(`/box/${this.id}/${++this.currentPageNum}`);
+      this.$ngSilentLocation.silent(`/box/${this.id}/${++this.currentPageNum}`);
       return this.fetch();
     }
-  };
-
-  this.edit = event => {
-    const useFullScreen = ($mdMedia('sm') || $mdMedia('xs'))  && $scope.customFullscreen;
-    $scope.$watch(function() {
-      return $mdMedia('xs') || $mdMedia('sm');
-    }, function(wantsFullScreen) {
-      $scope.customFullscreen = (wantsFullScreen === true);
+  }
+  edit (event) {
+    const useFullScreen =
+      (this.$mdMedia('sm') || this.$mdMedia('xs')) && this.$scope.customFullscreen;
+    this.$scope.$watch(() => {
+      return this.$mdMedia('xs') || this.$mdMedia('sm');
+    }, wantsFullScreen => {
+      this.$scope.customFullscreen = (wantsFullScreen === true);
     });
-    return Promise.resolve($mdDialog.show({
+    return Promise.resolve(this.$mdDialog.show({
       locals: {data: this.data},
       bindToController: true,
       controller: ['$mdDialog', editCtrl],
@@ -98,48 +107,46 @@ module.exports = function(
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.postAsync(`/api/v1/box/${this.id}`, editedData).then(() => {
+      return this.io.socket.patchAsync(`/api/v1/box/${this.id}`, editedData).then(() => {
         Object.assign(this.data, editedData);
-        if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes) {
-          const thisBox = $scope.$parent.main.boxes.find(box => box.id === this.id);
+        if (this.$scope.$parent && this.$scope.$parent.main && this.$scope.$parent.main.boxes) {
+          const thisBox = this.$scope.$parent.main.boxes.find(box => box.id === this.id);
           if (thisBox) Object.assign(thisBox, this.data);
         }
-        $scope.$apply();
+        this.$scope.$apply();
       });
-    })).catch(errorHandler);
-  };
-
-  this.delete = () => {
-    io.socket.deleteAsync(`/box/${this.id}`).then(() => {
+    })).catch(this.errorHandler);
+  }
+  delete () {
+    return this.io.socket.deleteAsync(`/box/${this.id}`).then(() => {
       this.isDeleted = true;
-      $scope.$apply();
-      if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes) {
-        const thisBoxIndex = $scope.$parent.main.boxes.findIndex(box => box.id === this.id);
+      this.$scope.$apply();
+      if (this.$scope.$parent && this.$scope.$parent.main && this.$scope.$parent.main.boxes) {
+        const thisBoxIndex = this.$scope.$parent.main.boxes.findIndex(box => box.id === this.id);
         if (thisBoxIndex !== -1) {
           this.indexInMain = thisBoxIndex;
-          $scope.$parent.main.boxes.splice(thisBoxIndex, 1);
+          this.$scope.$parent.main.boxes.splice(thisBoxIndex, 1);
         }
       }
-      $scope.$apply();
-    }).catch(errorHandler);
-  };
-
-  this.undelete = () => {
-    io.socket.postAsync(`/api/v1/box/${this.id}/undelete`).then(() => {
+      this.$scope.$apply();
+    }).catch(this.errorHandler);
+  }
+  undelete () {
+    return this.io.socket.postAsync(`/api/v1/box/${this.id}/undelete`).then(() => {
       this.isDeleted = false;
-      $scope.$apply();
-      if ($scope.$parent && $scope.$parent.main && $scope.$parent.main.boxes
+      this.$scope.$apply();
+      if (this.$scope.$parent && this.$scope.$parent.main && this.$scope.$parent.main.boxes
           && this.indexInMain !== null) {
-        $scope.$parent.main.boxes.splice(this.indexInMain, 0, this.data);
+        this.$scope.$parent.main.boxes.splice(this.indexInMain, 0, this.data);
         this.indexInMain = null;
       }
-    }).catch(errorHandler);
-  };
-  this.movePkmn = (pkmn, localIndex) => {
+    }).catch(this.errorHandler);
+  }
+  movePkmn (pkmn, localIndex) {
     const absoluteIndex = boxPageSize * (this.data.pageNum - 1) + localIndex;
-    return io.socket.postAsync(
+    return this.io.socket.postAsync(
       `/api/v1/pokemon/${pkmn.id}/move`,
       {box: this.id, index: absoluteIndex}
-    ).catch(errorHandler);
-  };
+    ).catch(this.errorHandler);
+  }
 };

--- a/client/login/login.ctrl.js
+++ b/client/login/login.ctrl.js
@@ -12,15 +12,19 @@ const ERRORS_MAP = {
   'Error.Passport.Bad.Username': 'invalid username (must be 1-20 alphanumeric characters)',
   'Error.Passport.Username.Taken': 'a user with that name already exists'
 };
-module.exports = function ($scope, $http) {
-  this.register = () => {
-    return $http({
+module.exports = class Login {
+  constructor ($scope, $http) {
+    this.$scope = $scope;
+    this.$http = $http;
+  }
+  register () {
+    return this.$http({
       method: 'POST',
       url: '/api/v1/auth/local/register',
       data: {
-        name: $scope.registerName,
-        password: $scope.registerPassword,
-        email: $scope.registerEmail
+        name: this.$scope.registerName,
+        password: this.$scope.registerPassword,
+        email: this.$scope.registerEmail
       }
     }).then(() => {
       window.location = '/';
@@ -32,14 +36,14 @@ module.exports = function ($scope, $http) {
         this.registerError = 'An unknown error occured.';
       }
     });
-  };
-  this.login = () => {
-    return $http({
+  }
+  login () {
+    return this.$http({
       method: 'POST',
       url: '/api/v1/auth/local',
       data: {
-        name: $scope.loginName,
-        password: $scope.loginPassword
+        name: this.$scope.loginName,
+        password: this.$scope.loginPassword
       }
     }).then(() => {
       window.location = '/';
@@ -51,5 +55,5 @@ module.exports = function ($scope, $http) {
         this.loginError = 'An unknown error occured.';
       }
     });
-  };
+  }
 };

--- a/client/pokemon/pokemon-edit.ctrl.js
+++ b/client/pokemon/pokemon-edit.ctrl.js
@@ -1,29 +1,27 @@
 /**
  * Controller for handling the dialog for editing a pokemon
  */
-module.exports = function ($mdDialog) {
-  this.visibilities = require('../../api/services/Constants.js').POKEMON_VISIBILITIES;
 
-  this.visibility = this.data.visibility;
-  this.publicNotes = this.data.publicNotes;
-  this.privateNotes = this.data.privateNotes;
-
-  this.cancel = function() {
-    $mdDialog.cancel();
-  };
-
-  this.canAdd = function () {
-    return Boolean(this.visibility);
-  };
-
-  this.answer = function() {
-    if (!this.visibility) {
-      return;
-    }
-    $mdDialog.hide({
+module.exports = class PokemonEdit {
+  constructor ($mdDialog) {
+    this.$mdDialog = $mdDialog;
+    this.visibilities = require('../../api/services/Constants').POKEMON_VISIBILITIES;
+    this.visibility = this.data.visibility;
+    this.publicNotes = this.data.publicNotes;
+    this.privateNotes = this.data.privateNotes;
+  }
+  cancel () {
+    this.$mdDialog.cancel();
+  }
+  canAdd () {
+    return !!this.visibility;
+  }
+  answer () {
+    if (!this.visibility) return;
+    this.$mdDialog.hide({
       visibility: this.visibility,
       publicNotes: this.publicNotes,
       privateNotes: this.privateNotes
     });
-  };
+  }
 };

--- a/client/pokemon/pokemon-full.view.html
+++ b/client/pokemon/pokemon-full.view.html
@@ -17,7 +17,7 @@
         </span>
       </div>
       <span flex></span>
-      <a ng-href="/pokemon/{{pokemon.id}}/pk6">
+      <a ng-href="/api/v1/pokemon/{{pokemon.id}}/pk6">
         <md-button class="md-icon-button" aria-label="Download .pk6 file" ng-show="pokemon.data.owner === main.user.name || main.user.isAdmin || pokemon.data.visibility === 'public'">
           <md-tooltip md-direction="left">Download .pk6 file</md-tooltip>
           <i class="material-icons">file_download</i>

--- a/client/prefs/prefs.ctrl.js
+++ b/client/prefs/prefs.ctrl.js
@@ -1,35 +1,41 @@
-module.exports = function (io, $mdToast, errorHandler) {
-  this.changePassword = () => {
+module.exports = class Prefs {
+  constructor (io, $mdToast, errorHandler) {
+    this.io = io;
+    this.$mdToast = $mdToast;
+    this.errorHandler = errorHandler;
+  }
+  changePassword () {
     if (this.newPassword1 !== this.newPassword2) {
-      return $mdToast.show(
-        $mdToast.simple().position('bottom right').textContent('Error: New passwords do not match')
+      return this.$mdToast.show(
+        this.$mdToast.simple().position('bottom right')
+          .textContent('Error: New passwords do not match')
       );
     }
     if (this.newPassword1.length < 8) {
-      return $mdToast.show(
-        $mdToast.simple().position('bottom right')
+      return this.$mdToast.show(
+        this.$mdToast.simple().position('bottom right')
           .textContent('Error: Passwords must be at least 8 characters long.')
       );
     }
     if (this.newPassword1.length > 72) {
-      return $mdToast.show(
-        $mdToast.simple().position('bottom right')
+      return this.$mdToast.show(
+        this.$mdToast.simple().position('bottom right')
           .textContent('Error: Passwords may not be longer than 72 characters.')
       );
     }
-    return io.socket.postAsync('/api/v1/changePassword', {
+    return this.io.socket.postAsync('/api/v1/changePassword', {
       oldPassword: this.oldPassword,
       newPassword: this.newPassword1
     }).then(() => {
       this.oldPassword = '';
       this.newPassword1 = '';
       this.newPassword2 = '';
-      return $mdToast.simple()
-        .position('bottom right').textContent('Password updated successfully');
+      return this.$mdToast.simple().position('bottom right')
+        .textContent('Password updated successfully');
     }).catch({statusCode: 403, body: 'Incorrect password'}, () => {
-      return $mdToast.simple().position('bottom right').textContent('Incorrect password');
+      return this.$mdToast.simple().position('bottom right').textContent('Incorrect password');
     }).then(toast => {
-      $mdToast.show(toast);
-    }).catch(errorHandler);
-  };
+      this.$mdToast.show(toast);
+    }).catch(this.errorHandler);
+  }
 };

--- a/client/profile/profile-edit.ctrl.js
+++ b/client/profile/profile-edit.ctrl.js
@@ -1,37 +1,41 @@
 /**
  * Controller for handling the dialog for editing profiles
  */
-module.exports = function ($mdDialog) {
+module.exports = class ProfileEdit {
+  constructor ($mdDialog) {
+    this.$mdDialog = $mdDialog;
 
-  this.friendCodes = this.data.friendCodes ? this.data.friendCodes.slice(0) : [''];
-  this.inGameNames = this.data.inGameNames ? this.data.inGameNames.slice(0) : [''];
-  this.tsvs = this.data.trainerShinyValues ? this.data.trainerShinyValues.slice(0) : [''];
+    this.friendCodes = this.data.friendCodes ? this.data.friendCodes.slice(0) : [''];
+    this.inGameNames = this.data.inGameNames ? this.data.inGameNames.slice(0) : [''];
+    this.tsvs = this.data.trainerShinyValues ? this.data.trainerShinyValues.slice(0) : [''];
 
-  if (this.friendCodes.length === 0) {
-    this.friendCodes = [''];
+    if (this.friendCodes.length === 0) {
+      this.friendCodes = [''];
+    }
+    if (this.inGameNames.length === 0) {
+      this.inGameNames = [''];
+    }
+    if (this.tsvs.length === 0) {
+      this.tsvs = [''];
+    }
   }
-  if (this.inGameNames.length === 0) {
-    this.inGameNames = [''];
+  addFC () {
+    this.friendCodes.push('');
   }
-  if (this.tsvs.length === 0) {
-    this.tsvs = [''];
+  addIGN () {
+    this.inGameNames.push('');
   }
-
-  this.addFC = () => this.friendCodes.push('');
-  this.addIGN = () => this.inGameNames.push('');
-  this.addTSV = () => this.tsvs.push('');
-
-  this.cancel = () => {
-    $mdDialog.cancel();
-  };
-
-  this.answer = () => {
-    $mdDialog.hide({
-      inGameNames: this.inGameNames.filter(removeEmpty),
-      friendCodes: this.friendCodes.filter(removeEmpty),
-      trainerShinyValues: this.tsvs.filter(removeEmpty)
+  addTSV () {
+    this.tsvs.push('');
+  }
+  cancel () {
+    this.$mdDialog.cancel();
+  }
+  answer () {
+    this.$mdDialog.hide({
+      inGameNames: this.inGameNames.filter(ign => ign),
+      friendCodes: this.friendCodes.filter(fc => fc),
+      trainerShinyValues: this.tsvs.filter(tsv => tsv)
     });
-  };
-
-  const removeEmpty = (el) => el !== '';
+  }
 };

--- a/client/profile/profile.ctrl.js
+++ b/client/profile/profile.ctrl.js
@@ -1,35 +1,42 @@
 const editCtrl = require('./profile-edit.ctrl.js');
 const angular = require('angular');
 
-module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog, errorHandler) {
-  this.data = this.data || {};
-  this.data.name = this.data.name || $routeParams.username;
-  this.errorStatusCode = null;
-
-  this.fetch = () => Promise.all([this.fetchInfo, this.fetchBoxes]);
-
-  this.fetchInfo = () => {
-    return io.socket.getAsync(`/api/v1/user/${this.data.name}`).then(res => {
+module.exports = class Profile {
+  constructor ($scope, $routeParams, io, $mdMedia, $mdDialog, errorHandler) {
+    this.$scope = $scope;
+    this.$routeParams = $routeParams;
+    this.io = io;
+    this.$mdMedia = $mdMedia;
+    this.$mdDialog = $mdDialog;
+    this.errorHandler = errorHandler;
+    this.data = this.data || {};
+    this.data.name = this.data.name || $routeParams.username;
+    this.errorStatusCode = null;
+  }
+  fetch () {
+    return Promise.all([this.fetchInfo(), this.fetchBoxes()]);
+  }
+  fetchInfo () {
+    return this.io.socket.getAsync(`/api/v1/user/${this.data.name}`).then(res => {
       Object.assign(this.data, res);
     }).catch(err => {
       this.errorStatusCode = err.statusCode;
-    }).then(() => $scope.$apply());
-  };
-
-  this.fetchBoxes = () => {
-    return io.socket.getAsync(`/api/v1/user/${this.data.name}/boxes`).then(res => {
+    }).catch(this.errorHandler).then(() => this.$scope.$apply());
+  }
+  fetchBoxes () {
+    return this.io.socket.getAsync(`/api/v1/user/${this.data.name}/boxes`).then(res => {
       this.data.boxes = res;
-    }).catch(errorHandler).then(() => $scope.$apply());
-  };
-
-  this.edit = event => {
-    const useFullScreen = ($mdMedia('sm') || $mdMedia('xs'))  && $scope.customFullscreen;
-    $scope.$watch(function() {
-      return $mdMedia('xs') || $mdMedia('sm');
-    }, function(wantsFullScreen) {
-      $scope.customFullscreen = (wantsFullScreen === true);
+    }).catch(this.errorHandler).then(() => this.$scope.$apply());
+  }
+  edit (event) {
+    const useFullScreen
+      = (this.$mdMedia('sm') || this.$mdMedia('xs')) && this.$scope.customFullscreen;
+    this.$scope.$watch(() => {
+      return this.$mdMedia('xs') || this.$mdMedia('sm');
+    }, wantsFullScreen => {
+      this.$scope.customFullscreen = (wantsFullScreen === true);
     });
-    return Promise.resolve($mdDialog.show({
+    return Promise.resolve(this.$mdDialog.show({
       locals: {data: this.data},
       bindToController: true,
       controller: ['$mdDialog', editCtrl],
@@ -40,10 +47,10 @@ module.exports = function($scope, $routeParams, io, $mdMedia, $mdDialog, errorHa
       clickOutsideToClose: true,
       fullscreen: useFullScreen
     }).then((editedData) => {
-      return io.socket.patchAsync('/api/v1/me', editedData).then(() => {
+      return this.io.socket.patchAsync('/api/v1/me', editedData).then(() => {
         Object.assign(this.data, editedData);
-        $scope.$apply();
+        this.$scope.$apply();
       });
-    })).catch(errorHandler);
-  };
+    })).catch(this.errorHandler);
+  }
 };

--- a/client/userMenu/user.ctrl.js
+++ b/client/userMenu/user.ctrl.js
@@ -2,10 +2,14 @@
  * A small controller to explain the syntax we will be using
  * @return {function} A controller that contains 2 test elements
  */
-module.exports = function(io) {
-  this.logout = function () {
-    io.socket.postAsync('/api/v1/logout', {}).then(() => {
+module.exports = class User {
+  constructor (io, errorHandler) {
+    this.io = io;
+    this.errorHandler = errorHandler;
+  }
+  logout () {
+    return this.io.socket.postAsync('/api/v1/logout', {}).then(() => {
       window.location = '/';
-    }).catch(console.error.bind(console));
-  };
+    }).catch(this.errorHandler);
+  }
 };

--- a/client/userMenu/user.module.js
+++ b/client/userMenu/user.module.js
@@ -14,6 +14,6 @@ ng.module('porybox.userMenu', [])
       name: '='
     },
     templateUrl: 'userMenu/user.view.html',
-    controller: ['io', controller],
+    controller: ['io', 'errorHandler', controller],
     controllerAs: 'userMenu'
   });


### PR DESCRIPTION
Given that the client controllers are considered as class constructors by angular, it will save some memory (and performance) to define prototype functions for them rather than redefining the functions for each instance.