### PR TITLE
Replace the pagination API

### DIFF
--- a/api/controllers/BoxController.js
+++ b/api/controllers/BoxController.js
@@ -33,25 +33,15 @@ module.exports = _.mapValues({
     const box = await Box.findOne({
       id: params.id,
       _markedForDeletion: false
-    }).populate('contents');
-    /* Parse contents of the box before slicing to get the page. This ensures that the slicing is done correctly
-    for the given user, without leaking information about the private contents of the box. However, it does result
-    in the server parsing some things that don't need to be parsed since they won't be sent to the client anyway.*/
+    });
     const safeBox = await PokemonHandler.getSafeBoxForUser(box, req.user);
-    const pageParam = req.param('page');
-    const pageNum = _.isUndefined(pageParam) ? 1 : +pageParam;
-    const totalPageCount = Math.ceil(safeBox.contents.length / Constants.BOX_PAGE_SIZE) || 1;
-    if (Number.isNaN(pageNum) || pageNum < 1 || pageNum > totalPageCount || pageNum % 1) {
-      return res.notFound();
-    }
-    safeBox.totalItemCount = safeBox.contents.length;
-    safeBox.totalPageCount = totalPageCount;
-    safeBox.pageNum = pageNum;
-    const startIndex = Constants.BOX_PAGE_SIZE * (pageNum - 1);
-    const endIndex = startIndex + Constants.BOX_PAGE_SIZE;
-    safeBox.contents = safeBox.contents.slice(startIndex, endIndex).map(
-      pkmn => PokemonHandler.pickPokemonFields(pkmn, params.pokemonFields)
-    );
+    safeBox.contents = await PokemonHandler.getSafeBoxSliceForUser({
+      box: safeBox,
+      user: req.user,
+      afterId: params.after,
+      beforeId: params.before,
+      sliceSize: Constants.BOX_PAGE_SIZE
+    }).map(pkmn => PokemonHandler.pickPokemonFields(pkmn, params.pokemonFields));
     return res.ok(safeBox);
   },
 

--- a/client/app.js
+++ b/client/app.js
@@ -5,7 +5,6 @@ require('angular-material');
 require('angular-messages');
 require('angular-route');
 require('ng-file-upload');
-require('ngsilent');
 require('angular-sortable-views');
 const Promise = require('bluebird');
 Promise.config({warnings: false});
@@ -38,7 +37,6 @@ const porybox = ng.module('porybox', [
 
   // Third party
   'ngMaterial',
-  'ngSilent',
   'ngRoute',
   'angular-sortable-view'
 ]);

--- a/client/box/box-list.view.html
+++ b/client/box/box-list.view.html
@@ -56,18 +56,7 @@
     <div flex-xs ng-repeat="pokemon in box.data.contents track by pokemon.id" sv-element>
       <pokemon-card data="pokemon" ng-class="{'draggable': box.draggingEnabled}"></pokemon-card>
     </div>
-  </div>
-
-  <div class="pagination-container">
-    <md-button class="md-icon-button" ng-click="box.prevPage()" ng-disabled="box.isLoading() || !box.hasPrevPage()">
-      <i class="material-icons">navigate_before</i>
-      <md-tooltip md-direction="left">Previous page</md-tooltip>
-    </md-button>
-    <span class="md-subhead">Page {{box.data.pageNum}} of {{box.data.totalPageCount}}</span>
-    <md-button class="md-icon-button" ng-click="box.nextPage()" ng-disabled="box.isLoading() || !box.hasNextPage()">
-      <i class="material-icons">navigate_next</i>
-      <md-tooltip md-direction="right">Next page</md-tooltip>
-    </md-button>
+    <md-progress-circular md-mode="indeterminate" ng-if="box.isLoading" md-diameter="166"></md-progress-circular>
   </div>
 </div>
 <div ng-if="box.errorStatusCode" ng-include="'/errors/' + box.errorStatusCode + '.html'"></div>

--- a/client/box/box.module.js
+++ b/client/box/box.module.js
@@ -17,7 +17,6 @@ ng.module('porybox.box', ['ngRoute'])
     templateUrl: 'box/box-card.view.html',
     controller: [
       '$scope',
-      '$ngSilentLocation',
       '$routeParams',
       'io',
       '$mdMedia',
@@ -32,7 +31,6 @@ ng.module('porybox.box', ['ngRoute'])
       templateUrl: '/box/box-list.view.html',
       controller: [
         '$scope',
-        '$ngSilentLocation',
         '$routeParams',
         'io',
         '$mdMedia',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "lodash": "^4.13.1",
     "moment": "^2.14.0",
     "ng-file-upload": "^12.0.4",
-    "ngsilent": "git://github.com/garakh/ngSilent/#a03fc023be4e154de9a1b4351e722e971e90384d",
     "passport": "^0.3.2",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -533,7 +533,8 @@ describe('PokemonController', () => {
     });
     it('does not show deleted contents when a box is retrieved', async () => {
       const res = await agent.get(`/api/v1/box/${pkmn.box}`);
-      const res2 = await agent.get(`/api/v1/box/${pkmn.box}`).query({page: 2});
+      const res2 = await agent.get(`/api/v1/box/${pkmn.box}`)
+        .query({after: _.last(res.body.contents).id});
       expect(_.map(res.body.contents.concat(res2.body.contents), 'id')).to.include(pkmn.id);
       await agent.del(`/api/v1/pokemon/${pkmn.id}`);
       const res3 = await agent.get(`/api/v1/box/${pkmn.box}`);


### PR DESCRIPTION
Relates to #345

See https://github.com/porygonco/porybox/issues/345#issuecomment-231894729 for an explanation of why the pagination API needed to be replaced

To do:

- [x] Implement the new API on the client
- [x] Fix a bug where a new page is fetched before you scroll down (possibly related to https://github.com/sroze/ngInfiniteScroll/pull/7#issuecomment-85194328)
- [x] Add a loading icon