### PR TITLE
Fix the invalid typeof check for the csrf token

### DIFF
--- a/client/layout.ejs
+++ b/client/layout.ejs
@@ -34,7 +34,7 @@
         <%- include footer.ejs %>
       </div>
     </div>
-    <div id="csrf-token"><%= typeof _csrf !== undefined ? _csrf : '' %></div>
+    <div id="csrf-token"><%= typeof _csrf !== 'undefined' ? _csrf : '' %></div>
     <div id="app-version"><%= VERSION %></div>
     <div id="user-data" ng-non-bindable>
       <%= _.escape(JSON.stringify({


### PR DESCRIPTION
In responses from res.forbidden(), the `_csrf` view local is not included (see https://github.com/balderdashy/sails/issues/2566). We had a typeof check to prevent this from causing an error, but that typeof check was invalid.