### PR TITLE
Use superagent-defaults for default request parameters in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "mocha": "^2.5.0",
     "phantomjs-prebuilt": "^2.1.4",
     "sails-memory": "^0.10.6",
+    "superagent-defaults": "^0.1.14",
     "supertest-as-promised": "^3.0.0"
   }
 }

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -26,11 +26,7 @@ before(function(done) {
       migrate: 'drop'
     },
     connection: 'testDB',
-    paths: { public: 'client', views: 'client' },
-    /* Disable CSRF for the unit tests. `supertest` currently has no mechanism to attach headers to
-    every request that gets made, which makes CSRF a bit annoying to deal with. Since it's handled internally
-    by sails anyway, there is not a great deal of benefit to testing with it. */
-    csrf: false
+    paths: { public: 'client', views: 'client' }
   }, function(err) {
     if (err) return done(err);
     // here you can load fixtures, etc.

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -1,19 +1,18 @@
 'use strict';
-const supertest = require('supertest-as-promised');
 const expect = require('chai').use(require('dirty-chai')).expect;
-require('babel-polyfill');
+const testHelpers = require('../test-helpers');
 
 describe('AuthController', function() {
   let agent;
   let otherAgent;
   let invalidAgent;
-  before(() => {
-    agent = supertest.agent(sails.hooks.http.app);
+  before(async () => {
+    agent = await testHelpers.getAgent();
   });
 
-  beforeEach(() => {
-    otherAgent = supertest.agent(sails.hooks.http.app);
-    invalidAgent = supertest.agent(sails.hooks.http.app);
+  beforeEach(async () => {
+    otherAgent = await testHelpers.getAgent();
+    invalidAgent = await testHelpers.getAgent();
   });
 
   describe('#login()', function () {
@@ -29,7 +28,7 @@ describe('AuthController', function() {
     });
 
     it('creates a box for the user after registering an account', async () => {
-      const firstBoxAgent = supertest.agent(sails.hooks.http.app);
+      const firstBoxAgent = await testHelpers.getAgent();
       const res = await firstBoxAgent.post('/api/v1/auth/local/register').send({
         name: 'firstBoxTester',
         password: 'f1rstB0xTest3r',
@@ -152,9 +151,9 @@ describe('AuthController', function() {
     let passAgent, passAgent2, passAgent3, username;
     beforeEach(async () => {
       username = `USERNAME_${require('crypto').randomBytes(4).toString('hex')}`;
-      passAgent = supertest.agent(sails.hooks.http.app);
-      passAgent2 = supertest.agent(sails.hooks.http.app);
-      passAgent3 = supertest.agent(sails.hooks.http.app);
+      passAgent = await testHelpers.getAgent();
+      passAgent2 = await testHelpers.getAgent();
+      passAgent3 = await testHelpers.getAgent();
       const res = await passAgent.post('/api/v1/auth/local/register').send({
         name: username,
         password: 'Correct Horse Battery Staple',
@@ -248,7 +247,7 @@ describe('AuthController', function() {
   describe('logging out', () => {
     let logoutAgent;
     beforeEach(async () => {
-      logoutAgent = supertest.agent(sails.hooks.http.app);
+      logoutAgent = await testHelpers.getAgent();
       const res = await logoutAgent.post('/api/v1/auth/local/register').send({
         name: 'logoutTester',
         password: "I can't think of any funny placeholder passwords right now",

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -1,15 +1,15 @@
 'use strict';
-const supertest = require('supertest-as-promised');
 const expect = require('chai').use(require('dirty-chai')).expect;
 const _ = require('lodash');
 const Promise = require('bluebird');
+const testHelpers = require('../test-helpers');
 describe('BoxController', () => {
   let agent, otherAgent, noAuthAgent, adminAgent;
   before(async () => {
-    agent = supertest.agent(sails.hooks.http.app);
-    otherAgent = supertest.agent(sails.hooks.http.app);
-    noAuthAgent = supertest.agent(sails.hooks.http.app);
-    adminAgent = supertest.agent(sails.hooks.http.app);
+    agent = await testHelpers.getAgent();
+    otherAgent = await testHelpers.getAgent();
+    noAuthAgent = await testHelpers.getAgent();
+    adminAgent = await testHelpers.getAgent();
     const res = await agent.post('/api/v1/auth/local/register').send({
       name: 'boxtester',
       password: '********',

--- a/test/controller/main.js
+++ b/test/controller/main.js
@@ -4,7 +4,7 @@ const request = require('supertest');
 describe('404', () => {
   it('should return 404 on nonexistent path', (done) => {
     request(sails.hooks.http.app)
-      .post('/api/v1/thiswillneverbevalid')
+      .get('/api/v1/thiswillneverbevalid')
       .expect(404, done);
   });
 });

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -1,15 +1,15 @@
 'use strict';
-const supertest = require('supertest-as-promised');
 const _ = require('lodash');
 const expect = require('chai').use(require('dirty-chai')).expect;
 const Promise = require('bluebird');
+const testHelpers = require('../test-helpers');
 describe('PokemonController', () => {
   let agent, otherAgent, noAuthAgent, adminAgent, generalPurposeBox;
   before(async () => {
-    agent = supertest.agent(sails.hooks.http.app);
-    otherAgent = supertest.agent(sails.hooks.http.app);
-    noAuthAgent = supertest.agent(sails.hooks.http.app);
-    adminAgent = supertest.agent(sails.hooks.http.app);
+    agent = await testHelpers.getAgent();
+    otherAgent = await testHelpers.getAgent();
+    noAuthAgent = await testHelpers.getAgent();
+    adminAgent = await testHelpers.getAgent();
     const res = await agent.post('/api/v1/auth/local/register').send({
       name: 'pk6tester',
       password: '********',

--- a/test/controller/user.js
+++ b/test/controller/user.js
@@ -1,17 +1,17 @@
 'use strict';
-const supertest = require('supertest-as-promised');
 const expect = require('chai').use(require('dirty-chai')).expect;
+const testHelpers = require('../test-helpers');
 describe('UserController', () => {
   let agent, adminAgent, noAuthAgent, generalPurposeBox;
   before(async () => {
-    agent = supertest.agent(sails.hooks.http.app);
+    agent = await testHelpers.getAgent();
     const res = await agent.post('/api/v1/auth/local/register').send({
       name: 'usertester',
       password: '********',
       email: 'usertester@usertesting.com'
     });
     expect(res.statusCode).to.equal(200);
-    adminAgent = supertest.agent(sails.hooks.http.app);
+    adminAgent = await testHelpers.getAgent();
     const res2 = await adminAgent.post('/api/v1/auth/local/register').send({
       name: 'IM_AN_ADMIN_FEAR_ME',
       password: '***********************************************************************',
@@ -19,7 +19,7 @@ describe('UserController', () => {
     });
     expect(res2.statusCode).to.equal(200);
     await sails.models.user.update({name: 'IM_AN_ADMIN_FEAR_ME'}, {isAdmin: true});
-    noAuthAgent = supertest.agent(sails.hooks.http.app);
+    noAuthAgent = await testHelpers.getAgent();
 
     const res3 = await agent.post('/api/v1/box').send({name: 'Boxer'});
     expect(res3.statusCode).to.equal(201);
@@ -287,7 +287,7 @@ describe('UserController', () => {
   describe('deleting an account', () => {
     let deleteAgent;
     beforeEach(async () => {
-      deleteAgent = supertest.agent(sails.hooks.http.app);
+      deleteAgent = await testHelpers.getAgent();
       const uniqueUsername = `deleteTester${require('crypto').randomBytes(4).toString('hex')}`;
       const res = await deleteAgent.post('/api/v1/auth/local/register').send({
         name: uniqueUsername,

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,0 +1,17 @@
+const supertest = require('supertest-as-promised');
+const defaults = require('superagent-defaults');
+const expect = require('chai').use(require('dirty-chai')).expect;
+
+module.exports = {
+  getAgent () {
+    const agent = defaults(supertest.agent(sails.hooks.http.app));
+    return agent.get('/csrfToken').then(res => {
+      expect(res.statusCode).to.equal(200);
+      agent.set('x-csrf-token', res.body._csrf);
+      /* Due to a quirk in how supertest-as-promised and superagent-defaults work together, a `.then` method gets attached
+      to the agent. We don't want the agent to be treated as a thenable when returning from this function, so just get rid of
+      the .then function. */
+      agent.then = undefined;
+    }).return(agent);
+  }
+};


### PR DESCRIPTION
This PR adds superagent-defaults as a devDependency, which allows custom defaults in request parameters. This means that we can stop disabling the CSRF protection for the tests because it's now possible to set a default `x-csrf-token` header without setting it explicitly for each request.