### PR TITLE
Escape special characters in nicknames correctly when downloading

### DIFF
--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -146,7 +146,7 @@ module.exports = _.mapValues({
     if (pokemon.visibility !== 'public' && !userIsOwner && !userIsAdmin) {
       return res.forbidden();
     }
-    res.header('Content-Disposition', `attachment; filename=${pokemon.nickname}-${pokemon.id}.pk6`);
+    res.attachment(`${pokemon.nickname}-${pokemon.id}.pk6`);
     res.status(200).send(Buffer.from(pokemon._rawPk6, 'base64'));
     if (!userIsOwner && pokemon.visibility === 'public') {
       await pokemon.incrementDownloadCount();

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -581,7 +581,7 @@ describe('PokemonController', () => {
       const res = await agent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer()
         .expect(
           'Content-Disposition',
-          `attachment; filename=${publicPkmn.nickname}-${publicPkmn.id}.pk6`
+          `attachment; filename="${publicPkmn.nickname}-${publicPkmn.id}.pk6"`
         );
       expect(res.statusCode).to.equal(200);
       expect(res.text).to.equal(rawPk6);
@@ -672,6 +672,15 @@ describe('PokemonController', () => {
       expect(finalPublicCount).to.equal(initialPublicCount + 1);
       expect(finalviewableCount).to.equal(initialviewableCount);
       expect(finalPrivateCount).to.equal(initialPrivateCount);
+    });
+    it('escapes special characters in nicknames correctly', async () => {
+      await sails.models.pokemon.update({id: publicPkmn.id}, {nickname: `\r\né∫ab;"'`});
+      const res = await agent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
+      expect(res.statusCode).to.equal(200);
+      expect(res.headers['content-disposition']).to.equal(
+        `attachment; filename="??é?ab;\\"'-${publicPkmn.id}.pk6"; ` +
+        `filename*=UTF-8''%0D%0A%C3%A9%E2%88%ABab%3B%22%27-${publicPkmn.id}.pk6`
+      );
     });
   });
   describe('moving a pokemon', () => {


### PR DESCRIPTION
Previously, we weren't escaping nicknames at all when setting the `Content-Disposition` header. This caused Node to throw an error if people set nicknames containing control characters, since we were putting those control characters directly into the header. (It's good that Node threw an error, because if it hadn't, people would have been able to modify the downloaded files themselves if the nickname started with `\r\n`.)

The resulting filenames will still be nonsense if the nicknames contain control characters, (they will be URL-encoded since most filesystems don't handle control characters in filenames very well). But that's fine, since a nickname would probably only contain control characters if it was an intentional attack on the server anyway.