### PR TITLE
Re-add the `no-console` linter rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
     'key-spacing': [2, {'beforeColon': false, 'afterColon': true}],
     // require a capital letter for constructors
     'new-cap': [2, {'newIsCap': true}],
-    'no-console': 0,
+    'no-console': 2,
     // disallow mixed spaces and tabs for indentation
     'no-mixed-spaces-and-tabs': 2,
     // disallow trailing whitespace at the end of lines

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 /**
  * app.js

--- a/client/app.js
+++ b/client/app.js
@@ -112,7 +112,7 @@ porybox.service('io', function () {
 porybox.service('errorHandler', ['$mdToast', function ($mdToast) {
   return reason => {
     if (reason) {
-      console.error(reason);
+      console.error(reason); // eslint-disable-line no-console
       $mdToast.show(
         $mdToast.simple().textContent('An unexpected error occured.').position('bottom right')
       );

--- a/client/login/login.ctrl.js
+++ b/client/login/login.ctrl.js
@@ -32,7 +32,6 @@ module.exports = class Login {
       if (res.status === 401 && ERRORS_MAP[res.data]) {
         this.registerError = ERRORS_MAP[res.data];
       } else {
-        console.error(res.data);
         this.registerError = 'An unknown error occured.';
       }
     });
@@ -51,7 +50,6 @@ module.exports = class Login {
       if (res.status === 401 && ERRORS_MAP[res.data]) {
         this.loginError = ERRORS_MAP[res.data];
       } else {
-        console.error(res.data);
         this.loginError = 'An unknown error occured.';
       }
     });


### PR DESCRIPTION
On the server we should be using `sails.log` instead of `console.log`, and on the client we should be using the `errorHandler` service for error handling anyway.