### PR TITLE
Refactor the login page

### DIFF
--- a/client/account/account.module.js
+++ b/client/account/account.module.js
@@ -4,7 +4,7 @@ const passwordCtrl = require('./password.ctrl');
 const infoCtrl = require('./info.ctrl');
 const prefsCtrl = require('./prefs.ctrl');
 
-ng.module('porybox.account', ['ngRoute'])
+ng.module('porybox.account', ['ngRoute', 'ngMessages'])
   .config(['$routeProvider', function($routeProvider) {
     $routeProvider.when('/account', {
       templateUrl: '/account/account.view.html',
@@ -14,7 +14,7 @@ ng.module('porybox.account', ['ngRoute'])
   }])
   .component('editPassword', {
     templateUrl: 'account/password.view.html',
-    controller: ['io', '$mdToast', 'errorHandler', passwordCtrl],
+    controller: ['$scope', 'io', '$mdToast', 'errorHandler', passwordCtrl],
     controllerAs: 'password'
   })
   .component('editInfo', {

--- a/client/account/password.ctrl.js
+++ b/client/account/password.ctrl.js
@@ -1,49 +1,29 @@
 module.exports = class Password {
-  constructor (io, $mdToast, errorHandler) {
+  constructor ($scope, io, $mdToast, errorHandler) {
+    this.$scope = $scope;
     this.io = io;
     this.$mdToast = $mdToast;
     this.errorHandler = errorHandler;
-
-    this.oldPassword = '';
-    this.newPassword1 = '';
-    this.newPassword2 = '';
   }
   changePassword () {
-    if (this.newPassword1 !== this.newPassword2) {
-      return this.$mdToast.show(
-        this.$mdToast.simple()
-          .position('bottom right')
-          .textContent('Error: New passwords do not match')
-      );
-    }
-    if (this.newPassword1.length < 8) {
-      return this.$mdToast.show(
-        this.$mdToast.simple()
-          .position('bottom right')
-          .textContent('Error: Passwords must be at least 8 characters long.')
-      );
-    }
-    if (this.newPassword1.length > 72) {
-      return this.$mdToast.show(
-        this.$mdToast.simple()
-          .position('bottom right')
-          .textContent('Error: Passwords may not be longer than 72 characters.')
-      );
-    }
     return this.io.socket.postAsync('/api/v1/changePassword', {
       oldPassword: this.oldPassword,
       newPassword: this.newPassword1
     }).then(() => {
-      this.oldPassword = '';
-      this.newPassword1 = '';
-      this.newPassword2 = '';
-      return this.$mdToast.simple()
+      this.reset();
+      return this.$mdToast.show(this.$mdToast.simple()
         .position('bottom right')
-        .textContent('Password updated successfully');
+        .textContent('Password updated successfully'));
     }).catch({statusCode: 403, body: 'Incorrect password'}, () => {
-      return this.$mdToast.simple().position('bottom right').textContent('Incorrect password');
-    }).then(toast => {
-      this.$mdToast.show(toast);
+      this.$scope.changePassword.oldPassword.$setValidity('correct', false);
+      this.$scope.$apply();
     }).catch(this.errorHandler);
+  }
+  reset () {
+    this.oldPassword = '';
+    this.newPassword1 = '';
+    this.newPassword2 = '';
+    this.$scope.changePassword.$setPristine();
+    this.$scope.changePassword.$setUntouched();
   }
 };

--- a/client/account/password.view.html
+++ b/client/account/password.view.html
@@ -10,19 +10,35 @@
         <form name="changePassword" method="POST">
           <md-input-container class="md-block">
             <label>Old password</label>
-            <input ng-model="password.oldPassword" type="password" name="oldPassword" aria-label="Old password">
+            <input
+              ng-model="password.oldPassword"
+              type="password"
+              name="oldPassword"
+              required
+              aria-label="Old password"
+              ng-change="changePassword.oldPassword.$setValidity('correct', true)"
+            >
+            <div ng-messages="changePassword.oldPassword.$error">
+              <div ng-message="correct">Incorrect password</div>
+            </div>
           </md-input-container>
           <md-input-container class="md-block">
             <label>New password</label>
-            <input ng-model="password.newPassword1" type="password" name="newPassword2" aria-label="New password">
+            <input ng-model="password.newPassword1" type="password" name="newPassword1" required minlength="8" maxlength="72" aria-label="New password">
+            <div ng-messages="changePassword.newPassword1.$error">
+              <div ng-message="minlength">Password must be at least 8 characters long.</div>
+            </div>
           </md-input-container>
           <md-input-container class="md-block">
             <label>Verify new password</label>
-            <input ng-model="password.newPassword2" type="password" name="newPassword2" aria-label="Verify new password">
+            <input ng-model="password.newPassword2" type="password" name="newPassword2" required minlength="8" maxlength="72" ng-pattern="{{password.newPassword1}}" aria-label="Verify new password">
+            <div ng-messages="changePassword.newPassword2.$error">
+              <div ng-message="pattern">Passwords do not match</div>
+            </div>
           </md-input-container>
 
           <md-card-actions layout="row" layout-align="start">
-            <md-button ng-click="password.changePassword()" type="submit">
+            <md-button ng-click="password.changePassword()" type="submit" ng-disabled="changePassword.$invalid">
               Change password
             </md-button>
           </md-card-actions>

--- a/client/login/login.ctrl.js
+++ b/client/login/login.ctrl.js
@@ -3,55 +3,52 @@
  * @return {function} A controller that contains 2 test elements
  */
 'use strict';
-const ERRORS_MAP = {
-  'Error.Passport.Password.Wrong': 'incorrect username/password combination',
-  'Error.Passport.Username.NotFound': 'incorrect username/password combination',
-  'Error.Passport.Email.Missing': 'invalid email address',
-  'Error.Passport.Password.Missing': 'missing password',
-  'Error.Passport.Password.Invalid': 'invalid password (must be at least 8 characters long)',
-  'Error.Passport.Bad.Username': 'invalid username (must be 1-20 alphanumeric characters)',
-  'Error.Passport.Username.Taken': 'a user with that name already exists'
-};
+import Promise from 'bluebird';
+const VALID_USERNAME_REGEX = require('../../api/services/Constants').VALID_USERNAME_REGEX;
+
 module.exports = class Login {
-  constructor ($scope, $http) {
+  constructor ($scope, $http, errorHandler) {
     this.$scope = $scope;
     this.$http = $http;
+    this.errorHandler = errorHandler;
+    this.VALID_USERNAME_REGEX = VALID_USERNAME_REGEX;
   }
   register () {
-    return this.$http({
+    return Promise.resolve(this.$http({
       method: 'POST',
       url: '/api/v1/auth/local/register',
       data: {
-        name: this.$scope.registerName,
-        password: this.$scope.registerPassword,
-        email: this.$scope.registerEmail
+        name: this.registerName,
+        password: this.registerPassword,
+        email: this.registerEmail
       }
-    }).then(() => {
+    })).then(() => {
       window.location = '/';
-    }).catch(res => {
-      if (res.status === 401 && ERRORS_MAP[res.data]) {
-        this.registerError = ERRORS_MAP[res.data];
-      } else {
-        this.registerError = 'An unknown error occured.';
+    }).catch(
+      {status: 401, data: 'Error.Passport.Username.Taken'},
+      () => {
+        this.$scope.registerForm.name.$setValidity('available', false);
+        this.$scope.$apply();
       }
-    });
+    ).catch(this.errorHandler);
   }
   login () {
-    return this.$http({
+    return Promise.resolve(this.$http({
       method: 'POST',
       url: '/api/v1/auth/local',
       data: {
-        name: this.$scope.loginName,
-        password: this.$scope.loginPassword
+        name: this.loginName,
+        password: this.loginPassword
       }
-    }).then(() => {
+    })).then(() => {
       window.location = '/';
-    }).catch(res => {
-      if (res.status === 401 && ERRORS_MAP[res.data]) {
-        this.loginError = ERRORS_MAP[res.data];
-      } else {
-        this.loginError = 'An unknown error occured.';
+    }).catch(
+      {status: 401, data: 'Error.Passport.Password.Wrong'},
+      {status: 401, data: 'Error.Passport.Username.NotFound'},
+      () => {
+        this.$scope.loginForm.password.$setValidity('correct', false);
+        this.$scope.$apply();
       }
-    });
+    ).catch(this.errorHandler);
   }
 };

--- a/client/login/login.module.js
+++ b/client/login/login.module.js
@@ -7,19 +7,19 @@ const controller = require('./login.ctrl');
  * @param  {[type]} []             [description]
  * @return {[type]}                [description]
  */
-ng.module('porybox.login', ['ngRoute'])
+ng.module('porybox.login', ['ngRoute', 'ngMessages'])
   .component('loginForm',
   {
     bindings: {},
     templateUrl: 'login/login.view.html',
-    controller: ['$scope', '$http', controller],
+    controller: ['$scope', '$http', 'errorHandler', controller],
     controllerAs: 'auth'
   })
   .component('registrationForm',
   {
     bindings: {},
     templateUrl: 'login/register.view.html',
-    controller: ['$scope', '$http', controller],
+    controller: ['$scope', '$http', 'errorHandler', controller],
     controllerAs: 'auth'
   }).config(['$routeProvider', function ($routeProvider) {
     $routeProvider.when('/login', {

--- a/client/login/login.view.html
+++ b/client/login/login.view.html
@@ -5,19 +5,26 @@
     </div>
   </md-toolbar>
   <md-card-content>
-    <form role="form" ng-submit="auth.login()" method="POST">
+    <form role="form" name="loginForm" ng-submit="auth.login()" method="POST">
       <md-input-container class="md-block">
-        <input type="text" name="username" ng-model="loginName">
+        <input type="text" name="username" required ng-model="auth.loginName" aria-label="Username">
         <label>Username</label>
       </md-input-container>
       <md-input-container class="md-block">
-        <input type="password" name="password" ng-model="loginPassword">
+        <input
+          type="password" name="password"
+          required
+          ng-model="auth.loginPassword"
+          aria-label="Password"
+          ng-change="loginForm.password.$setValidity('correct', true)"
+        >
         <label>Password</label>
+        <div ng-messages="loginForm.password.$error">
+          <div ng-message="correct">Incorrect username/password combination</div>
+        </div>
       </md-input-container>
-      <span ng-if="auth.loginError">{{auth.loginError}}<br></span>
-
       <md-card-actions layout="row" layout-align="center">
-        <md-button type="submit" class="md-raised">Sign in</md-button>
+        <md-button type="submit" class="md-raised" ng-disabled="loginForm.$invalid">Sign in</md-button>
       </md-card-actions>
     </form>
   </md-card-content>

--- a/client/login/register.view.html
+++ b/client/login/register.view.html
@@ -7,23 +7,44 @@
   <md-card-content>
     <div layout="column" layout-padding>
       <md-content class="autoscroll">
-        <form role="form" ng-submit="auth.register()">
+        <form role="form" name="registerForm" ng-submit="auth.register()" method="POST">
           <md-input-container class="md-block">
-            <input type="email" name="email" ng-model="registerEmail">
+            <input type="email" name="email" required ng-model="auth.registerEmail" aria-label="Email (will not be made public)">
             <label>Email (will not be made public)</label>
           </md-input-container>
           <md-input-container class="md-block">
-            <input type="text" name="name" ng-model="registerName">
+            <input
+              type="text"
+              name="name"
+              maxlength="20"
+              ng-pattern="auth.VALID_USERNAME_REGEX"
+              required
+              ng-model="auth.registerName"
+              aria-label="Username"
+              ng-change="registerForm.name.$setValidity('available', true)"
+            >
             <label>Username</label>
+            <div ng-messages="registerForm.name.$error">
+              <div ng-message="pattern">Username may only contain alphanumeric characters, hyphens, and underscores</div>
+              <div ng-message="available">An account with that name already exists</div>
+            </div>
           </md-input-container>
           <md-input-container class="md-block">
-            <input type="password" name="password" ng-model="registerPassword">
+            <input type="password" name="password" minlength="8" maxlength="72" required ng-model="auth.registerPassword" aria-label="Password">
             <label>Password</label>
+            <div ng-messages="registerForm.password.$error">
+              <div ng-message="minlength">Password must be at least 8 characters long</div>
+            </div>
           </md-input-container>
-          <span ng-if="auth.registerError">{{auth.registerError}}<br></span>
-
+          <md-input-container class="md-block">
+            <input type="password" name="password2" required ng-pattern="{{auth.registerPassword}}" aria-label="Verify password" ng-model="auth.password2">
+            <label>Verify password</label>
+            <div ng-messages="registerForm.password2.$error">
+              <div ng-message="pattern">Passwords do not match</div>
+            </div>
+          </md-input-container>
           <md-card-actions layout="row" layout-align="center">
-            <md-button type="submit" class="md-raised">Sign up</md-button>
+            <md-button type="submit" class="md-raised" ng-disabled="registerForm.$invalid">Sign up</md-button>
           </md-card-actions>
           <p class="md-body-1" style="text-align: center;">By registering, you agree to the Porybox <a href="/tos">terms of service</a>
             and <a href="privacy-policy">privacy policy</a>.</p>


### PR DESCRIPTION
fixes #197, fixes #360, fixes #391 

The login page now uses toast to display errors, rather than the [odd placeholder line](https://i.gyazo.com/f5e3a496892d12474d215193f01d714e.png) from before. It also adds better clientside validation so that people can notice that there is an error before they submit the form.