### PR TITLE
Add some security headers

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -23,7 +23,22 @@ module.exports.http = {
 
   middleware: {
     xframe: (req, res, next) => {
-      res.header('X-FRAME-OPTIONS', 'SAMEORIGIN');
+      res.header('X-Frame-Options', 'SAMEORIGIN');
+      next();
+    },
+
+    xss: (req, res, next) => {
+      res.header('X-XSS-Protection', '1; mode=block');
+      next();
+    },
+
+    contentType: (req, res, next) => {
+      res.header('X-Content-Type-Options', 'nosniff');
+      next();
+    },
+
+    csp: (req, res, next) => {
+      res.header('Content-Security-Policy', "default-src 'self' ; script-src 'self' 'unsafe-inline' *.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src * data:; font-src 'self' https://fonts.gstatic.com; connect-src *; frame-ancestors 'self' ; form-action 'self' ; reflected-xss block;");
       next();
     },
 
@@ -35,7 +50,6 @@ module.exports.http = {
   ***************************************************************************/
 
     order: [
-      'xframe',
       'startRequestTimer',
       'cookieParser',
       'session',
@@ -44,6 +58,10 @@ module.exports.http = {
       'handleBodyParserError',
       'compress',
       'methodOverride',
+      'xframe',
+      'xss',
+      'contentType',
+      'csp',
       '$custom',
       'router',
       'www',

--- a/test/controller/auth.js
+++ b/test/controller/auth.js
@@ -264,10 +264,24 @@ describe('AuthController', function() {
   });
 
   describe('misc. security', async () => {
-    it('sends an x-frame-options: SAMEORIGIN header on every request', async () => {
-      const res = await agent.get('/');
+    let res;
+    before(async () => {
+      res = await agent.get('/');
       expect(res.statusCode).to.equal(200);
+    });
+    it('sends an x-frame-options: SAMEORIGIN header on every request', async () => {
       expect(res.header['x-frame-options']).to.equal('SAMEORIGIN');
+    });
+    it('sends an x-xss-protection: 1; mode=block header on every request', async () => {
+      expect(res.header['x-xss-protection']).to.equal('1; mode=block');
+    });
+    it('sends an x-content-type-options: nosniff header on every request', async () => {
+      expect(res.header['x-content-type-options']).to.equal('nosniff');
+    });
+    it('sends a content-security-policy header to only allow scripts from self', async () => {
+      expect(res.header['content-security-policy']).to.equal(
+        "default-src 'self' ; script-src 'self' 'unsafe-inline' *.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src * data:; font-src 'self' https://fonts.gstatic.com; connect-src *; frame-ancestors 'self' ; form-action 'self' ; reflected-xss block;"
+      );
     });
   });
 });


### PR DESCRIPTION
* `X-XSS-Protection: 1; mode=block`: tells browsers not to run certain scripts if it detects that they were created from XSS issues
* `X-Content-Type-Options: nosniff`: Prevents browser from inferring MIME types (see [here](https://msdn.microsoft.com/en-us/library/gg622941(v=vs.85).aspx) for more info)
* `Content-Security-Policy: default-src 'self' ; script-src 'self' 'unsafe-inline' *.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src * ; font-src 'self' https://fonts.gstatic.com; connect-src *; frame-ancestors 'self' ; form-action 'self' ; reflected-xss block;`: Prevents the browser from accessing any resources on different domains, except explicit domains where we allow it. This is used to reduce the effect of an XSS attack if one appeared.