### PR TITLE
Clear a user's sessions when their password is reset/changed

### DIFF
--- a/api/controllers/PasswordResetController.js
+++ b/api/controllers/PasswordResetController.js
@@ -61,6 +61,7 @@ module.exports = _.mapValues({
     const user = await User.findOne({name: resetRequest.owner});
     await Promise.promisify(req.login.bind(req))(user);
     req.session.authenticated = true;
+    await user.clearSessions(req.sessionStore, req.sessionID);
     res.ok();
     sails.log.info(`The user ${user.name} successfully reset their password from IP ${req.headers['x-forwarded-for'] || req.ip}`);
   }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -96,14 +96,15 @@ module.exports = _.mapValues({
       accessToken: require('crypto').randomBytes(48).toString('base64')
     }).then()
       .catchThrow({code: 'E_VALIDATION'}, {statusCode: 400, message: 'Invalid new password'});
-    // Once the new Passport has been created, delete all of the user's old Passports. This has the effect
-    // of clearing the user's sessions.
+    // Once the new Passport has been created, delete all of the user's old Passports.
     await Passport.destroy({
       user: req.user.name,
       protocol: 'local',
       // Omit the newly-created Passport -- this line is necessary because the old/new passwords might be the same.
       id: {not: newPassport.id}
     });
+    // Clear the user's existing sessions, excluding this one.
+    await req.user.clearSessions(req.sessionStore, req.sessionID);
     return res.ok();
   },
   async changeEmail (req, res) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -81,6 +81,14 @@ module.exports =  {
       return _.omit(this, (value, key) => {
         return key.startsWith('_') || ['updatedAt', 'passports'].includes(key);
       });
+    },
+    async clearSessions (sessionStore, excludeSessionId) {
+      Validation.sanityCheck(_.isString(this.name));
+      const collection = sessionStore.db.collection(sails.config.session.collection);
+      return Promise.promisify(collection.remove.bind(collection))({
+        'session.passport.user': this.name,
+        _id: {$ne: excludeSessionId}
+      });
     }
   }
 };

--- a/config/local.example.js
+++ b/config/local.example.js
@@ -25,7 +25,8 @@ module.exports = {
     adapter: 'connect-mongo',
     url: 'mongodb://localhost:27017/porybox',
     // url: 'mongodb://username:pass@localhost:27017/porybox'
-    collection: 'sessions'
+    collection: 'sessions',
+    stringify: false
   },
 
   email: {


### PR DESCRIPTION
Note: This change requires a small database migration. Open your local mongo shell (e.g. `sudo mongo` while the database is running). Then enter `use porybox` to select the database, and run:

```js
db.sessions.find().snapshot().forEach(function(doc) { doc.session = JSON.parse(doc.session); db.sessions.save(doc); })
```

To undo this (e.g. if you want to check out another branch before this PR is merged):

```js
db.sessions.find().snapshot().forEach(function(doc) { doc.session = JSON.stringify(doc.session); db.sessions.save(doc); })
```