### PR TITLE
Add a config option for read-only mode

### DIFF
--- a/api/policies/readOnlyMode.js
+++ b/api/policies/readOnlyMode.js
@@ -1,0 +1,6 @@
+module.exports = (req, res, next) => {
+  if (sails.config.readOnly && req.method.toLowerCase() !== 'get') {
+    return res.status(405).json('READONLY');
+  }
+  return next();
+};

--- a/client/app.js
+++ b/client/app.js
@@ -53,6 +53,7 @@ const porybox = ng.module('porybox', [
 
 porybox.controller('MainCtrl', ['$mdToast', function ($mdToast) {
   this.selected = {};
+  this.serverStatus = SERVER_STATUS;
   Object.assign(this, userData);
   // TODO: Figure out a better way to do this
   const LOGGED_IN_ONLY_ROUTES = ['#/prefs', '#/account', '', '#/'];
@@ -64,7 +65,7 @@ porybox.controller('MainCtrl', ['$mdToast', function ($mdToast) {
     location.hash = '/';
   }
   // TODO: Disable some buttons clientside in read-only mode
-  if (SERVER_STATUS.readOnly) {
+  if (this.serverStatus.readOnly) {
     $mdToast.show(
       $mdToast.simple()
         .textContent('Porybox is temporarily in read-only mode while we perform maintenance.')

--- a/client/header.ejs
+++ b/client/header.ejs
@@ -9,8 +9,12 @@
 
     <span flex></span>
 
+    <md-icon ng-if="main.serverStatus.readOnly" md-offset="10 50" aria-label>
+      <md-tooltip>Porybox is temporarily in read-only mode.</md-tooltip>
+      <i class="material-icons">error</i>
+    </md-icon>
     <% if (typeof user !== 'undefined') {%>
-      <add-menu boxes="main.boxes" prefs="main.prefs" selected="main.selected"></add-menu>
+      <add-menu ng-if="!main.serverStatus.readOnly" boxes="main.boxes" prefs="main.prefs" selected="main.selected" server-status="main.serverStatus"></add-menu>
       <md-button aria-label="Help & FAQ" href="/#/faq">Help & FAQ</md-button>
       <user-menu name="'<%= user.name %>'"></user-menu>
     <% } else { %>

--- a/client/layout.ejs
+++ b/client/layout.ejs
@@ -34,14 +34,21 @@
         <%- include footer.ejs %>
       </div>
     </div>
-    <div id="csrf-token"><%= typeof _csrf !== 'undefined' ? _csrf : '' %></div>
-    <div id="app-version"><%= VERSION %></div>
-    <div id="user-data" ng-non-bindable>
-      <%= _.escape(JSON.stringify({
-        boxes: typeof boxes !== 'undefined' ? boxes : [],
-        user: typeof user !== 'undefined' ? user : null,
-        prefs: typeof prefs !== 'undefined' ? prefs : {}
-      })) %>
+    <div ng-non-bindable id="hidden-info">
+      <div id="csrf-token"><%= typeof _csrf !== 'undefined' ? _csrf : '' %></div>
+      <div id="app-version"><%= VERSION %></div>
+      <div id="user-data">
+        <%= _.escape(JSON.stringify({
+          boxes: typeof boxes !== 'undefined' ? boxes : [],
+          user: typeof user !== 'undefined' ? user : null,
+          prefs: typeof prefs !== 'undefined' ? prefs : {}
+        })) %>
+      </div>
+      <div id="server-status">
+        <%= _.escape(JSON.stringify({
+          readOnly: sails.config.readOnly
+        })) %>
+      </div>
     </div>
     <script src="<%=
       (sails.config.environment === 'development' ? '/bundle.js' : '/bundle.min.js') + '?v=' + VERSION

--- a/client/static/faq.html
+++ b/client/static/faq.html
@@ -65,6 +65,13 @@
     </p>
 
     <p>
+      <div class="md-body-2">What is read-only mode?</div>
+      Read-only mode is enabled when Porybox is under maintenance in order to protect your data.
+      When read-only mode is on, you will still be able to view things that have already been uploaded, but you will not be able to upload files or change anything on your account or boxes.<br/>
+      Maintenance usually does not last for more than a day. If Porybox is undergoing maintenance, you can check <a class="md-body-2" href="https://www.reddit.com/r/porybox" target="_blank" rel="noreferrer">/r/porybox</a> for more information.
+    </p>
+
+    <p>
       <div class="md-body-2">Is my data safe?</div>
       Your data is regularly backed up to an third-party server.
     </p>

--- a/client/styles/importer.less
+++ b/client/styles/importer.less
@@ -543,7 +543,7 @@ span[class^='gender-'] {
 /*******************************
  * Hidden divs
  *******************************/
-#csrf-token, #app-version, #user-data {
+#hidden-info {
   display: none;
 }
 

--- a/config/local.example.js
+++ b/config/local.example.js
@@ -45,5 +45,7 @@ module.exports = {
   },
 
   // The URL that appears in emails from the site
-  siteUrl: 'localhost:1337'
+  siteUrl: 'localhost:1337',
+
+  readOnly: false
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -16,10 +16,10 @@
  * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.policies.html
  */
 
-const anyone = ['passport'];
-const user = ['passport', 'sessionAuth'];
-const passwordProtected = ['passport', 'sessionAuth', 'passwordRequired'];
-const admin = ['passport', 'sessionAuth', 'isAdmin'];
+const anyone = ['readOnlyMode', 'passport'];
+const user = ['readOnlyMode', 'passport', 'sessionAuth'];
+const passwordProtected = ['readOnlyMode', 'passport', 'sessionAuth', 'passwordRequired'];
+const admin = ['readOnlyMode', 'passport', 'sessionAuth', 'isAdmin'];
 
 module.exports.policies = {
 


### PR DESCRIPTION
* Server returns a 405 response to any non-GET request
* A toast displays on the client when the page loads to notify the user about read-only mode. It also displays if the user attempts to something that's not allowed during read-only mode.