### PR TITLE
Lock angular-material to v1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "angular-animate": "^1.5.0",
     "angular-aria": "^1.5.0",
     "angular-marked": "^1.2.2",
-    "angular-material": "^1.0.7",
+    "angular-material": "~1.0.9",
     "angular-messages": "^1.5.3",
     "angular-route": "^1.5.5",
     "angular-sortable-views": "^0.1.0",


### PR DESCRIPTION
angular-material [doesn't appear to follow semver](https://github.com/angular/material/blob/master/CHANGELOG.md#110-2016-08-14), and they introduced several breaking changes in v1.1.0. We should lock the version to v1.0.x until we figure out how to fix the things that break in the newer version.