### PR TITLE
Remove babel-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,25 +1,9 @@
-parser: babel-eslint
 env:
   es6: true
   node: true
-ecmaFeatures:
-  arrowFunctions: true
-  blockBindings: true
-  classes: true
-  defaultParams: true
-  destructuring: false
-  forOf: true
-  generators: false
-  modules: true
-  objectLiteralComputedProperties: true
-  objectLiteralDuplicateProperties: false
-  objectLiteralShorthandMethods: true
-  objectLiteralShorthandProperties: true
-  restParams: false
-  spread: false
-  superInFunctions: true
-  templateStrings: true
-  jsx: true
+parserOptions:
+  ecmaVersion: 2017
+  sourceType: module
 rules:
   eqeqeq: 2
   indent: [2, 2]

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,79 +1,73 @@
-{
-  "parser": "babel-eslint",
-  'env': {
-    'es6': true,
-    'node': true
-  },
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': false,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'restParams': false,
-    'spread': false,
-    'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true
-  },
-  'rules': {
-    'eqeqeq': 2,
-    "indent": [2, 2],
-    // disallow modifying variables that are declared using const
-    'no-const-assign': 2,
-    // require let or const instead of var
-    'no-var': 2,
-    // suggest using of const declaration for variables that are never modified after declared
-    'prefer-const': 1,
-    // enforce one true brace style
-    'brace-style': [2, '1tbs', {'allowSingleLine': true }],
-    // require camel case names
-    'camelcase': [2, {'properties': 'never'}],
-    // enforce one true comma style
-    'comma-style': [2, 'last'],
-    // enforce newline at the end of file, with no multiple empty lines
-    'eol-last': 2,
-    // enforces spacing between keys and values in object literal properties
-    'key-spacing': [2, {'beforeColon': false, 'afterColon': true}],
-    // require a capital letter for constructors
-    'new-cap': [2, {'newIsCap': true}],
-    'no-console': 2,
-    // disallow mixed spaces and tabs for indentation
-    'no-mixed-spaces-and-tabs': 2,
-    // disallow trailing whitespace at the end of lines
-    'no-trailing-spaces': 2,
-    // disallow declaration of variables that are not used in the code
-    'no-unused-expressions': 2,
-    'no-unused-vars': 1,
-    // require all variables to be defined
-    'no-undef': "error",
-    // specify whether double or single quotes should be used
-    'quotes': [2, 'single', 'avoid-escape'],
-    'semi': 1,
-    // enforce spacing before and after semicolons
-    'semi-spacing': [2, {'before': false, 'after': true}],
-    // require spaces around operators
-    'space-infix-ops': 2,
-    // require spaces following keywords
-    'keyword-spacing': 2,
-    // warn when line length is greater than 80 characters
-    'max-len': [1, 100, 2, { 'ignoreComments': true, 'ignoreUrls': true, 'ignorePattern': 'sails\.log' }]
-  },
-  'globals': {
-    'sails': true,
-    'describe': true,
-    'it': true,
-    'before': true,
-    'beforeEach': true,
-    'after': true,
-    'afterEach': true
-  },
-  'extends': "eslint:recommended",
-}
+parser: babel-eslint
+env:
+  es6: true
+  node: true
+ecmaFeatures:
+  arrowFunctions: true
+  blockBindings: true
+  classes: true
+  defaultParams: true
+  destructuring: false
+  forOf: true
+  generators: false
+  modules: true
+  objectLiteralComputedProperties: true
+  objectLiteralDuplicateProperties: false
+  objectLiteralShorthandMethods: true
+  objectLiteralShorthandProperties: true
+  restParams: false
+  spread: false
+  superInFunctions: true
+  templateStrings: true
+  jsx: true
+rules:
+  eqeqeq: 2
+  indent: [2, 2]
+  # disallow modifying variables that are declared using const
+  no-const-assign: 2
+  # require let or const instead of var
+  no-var: 2
+  # suggest using of const declaration for variables that are never modified after declared
+  prefer-const: 1
+  # enforce one true brace style
+  brace-style: [2, 1tbs, {allowSingleLine: true }]
+  # require camel case names
+  camelcase: [2, {properties: never}]
+  # enforce one true comma style
+  comma-style: [2, last]
+  # enforce newline at the end of file, with no multiple empty lines
+  eol-last: 2
+  # enforces spacing between keys and values in object literal properties
+  key-spacing: [2, {beforeColon: false, afterColon: true}]
+  # require a capital letter for constructors
+  new-cap: [2, {newIsCap: true}]
+  no-console: 2
+  # disallow mixed spaces and tabs for indentation
+  no-mixed-spaces-and-tabs: 2
+  # disallow trailing whitespace at the end of lines
+  no-trailing-spaces: 2
+  # disallow declaration of variables that are not used in the code
+  no-unused-expressions: 2
+  no-unused-vars: 1
+  # require all variables to be defined
+  no-undef: error
+  # specify whether double or single quotes should be used
+  quotes: [2, single, avoid-escape]
+  semi: 1
+  # enforce spacing before and after semicolons
+  semi-spacing: [2, {before: false, after: true}]
+  # require spaces around operators
+  space-infix-ops: 2
+  # require spaces following keywords
+  keyword-spacing: 2
+  # warn when line length is greater than 80 characters
+  max-len: [1, 100, 2, {ignoreComments: true, ignoreUrls: true, ignorePattern: sails\.log}]
+globals:
+  sails: true
+  describe: true
+  it: true
+  before: true
+  beforeEach: true
+  after: true
+  afterEach: true
+extends: eslint:recommended

--- a/package.json
+++ b/package.json
@@ -67,10 +67,9 @@
   "license": "",
   "devDependencies": {
     "angular-mocks": "^1.5.8",
-    "babel-eslint": "^6.1.2",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
-    "eslint": "^3.2.0",
+    "eslint": "^3.7.1",
     "karma": "^1.2.0",
     "karma-browserify": "^5.0.1",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
Also see #506 

tl;dr: We don't need babel-eslint anymore since ESLint supports async/await on its own now.

This PR also removes some unnecessary punctuation from our .eslintrc file.