### PR TITLE
Add gender symbols to card view

### DIFF
--- a/client/pokemon/pokemon-card.view.html
+++ b/client/pokemon/pokemon-card.view.html
@@ -26,25 +26,34 @@
         <span class="language-tag" layout-align="end" title="Language">{{::pokemon.data.language}}</span>
       </div>
       <div layout="row" layout-align="none center">
-        <div flex style="font-weight:bold;" title="Species">{{::pokemon.speciesWithForme}}<span ng-if="::pokemon.data.isEgg"> (Egg)</span></div>
+        <div flex title="Species">
+          <span style="font-weight: bold;">
+            {{::pokemon.data.speciesName}}
+            <span ng-if="::pokemon.data.isEgg"> (Egg)</span>
+          </span>
+          <span class="gender-male" ng-if="::pokemon.data.gender == 'M'">&#9794;</span>
+          <span class="gender-female" ng-if="::pokemon.data.gender == 'F'">&#9792;</span>
+        </div>
         <md-icon ng-if="::pokemon.data.isShiny" md-svg-icon="/img/icons/star.svg" aria-label="shiny" class="pokemon-shiny" title="Shiny"></md-icon>
         <md-icon ng-if="::pokemon.isKB" md-svg-icon="/img/icons/kb.svg" aria-label="pentagon" class="pokemon-kb" style="margin-left: 5px;" title="Originated from Gen 6"></md-icon>
       </div>
+      <span ng-if="::pokemon.data.formName" style="font-weight: bold; line-height: 1.1em">{{::pokemon.data.formName}}</span>
       <div layout="row" layout-align="none center">
         <div flex title="Level">Level {{::pokemon.data.level}}</div>
-        <span layout-align="end">
-          <i ng-if="::pokemon.data.visibility === 'private'" class="material-icons small" title="Private">lock</i>
-          <i ng-if="::pokemon.data.visibility === 'viewable'" class="material-icons small" title="Viewable">visibility</i>
-          <i ng-if="::pokemon.data.visibility === 'public'" class="material-icons small" title="Public">public</i>
-        </span>
       </div>
       <div flex ng-if="::!pokemon.data.increasedStat" title="Neutral nature">{{::pokemon.data.natureName}}</div>
       <div flex ng-if="::pokemon.data.increasedStat" ng-attr-title="+{{::pokemon.data.increasedStat}}, -{{::pokemon.data.decreasedStat}}">{{::pokemon.data.natureName}}</div>
       <div flex ng-class="::{'pokemon-ha': pokemon.hasHA}" ng-attr-title="{{pokemon.hasHA ? 'Ability (HA)' : 'Ability'}}">{{::pokemon.data.abilityName}}</div>
       <div flex title="OT, TID">{{::pokemon.parsedOt}}, {{::pokemon.paddedTid}}</div>
-      <div layout="row" layout-align="none center">
+      <div layout="row" layout-align="none end">
         <span ng-repeat="iv in ::pokemon.ivs track by $index"><span ng-class="::{'increased-stat': $index === pokemon.natureStats[0],
                       'decreased-stat': $index === pokemon.natureStats[1]}">{{::iv}}</span>{{::$last ? '' : '.'}}</span>
+        <span flex></span>
+        <span layout-align="end">
+          <i ng-if="::pokemon.data.visibility === 'private'" class="material-icons small" title="Private">lock</i>
+          <i ng-if="::pokemon.data.visibility === 'viewable'" class="material-icons small" title="Viewable">visibility</i>
+          <i ng-if="::pokemon.data.visibility === 'public'" class="material-icons small" title="Public">public</i>
+        </span>
       </div>
     </md-card-content>
 </md-card>

--- a/client/styles/importer.less
+++ b/client/styles/importer.less
@@ -33,6 +33,7 @@ i.material-icons.small {
 
 .layout-align-end-stretch i.material-icons.small {
   margin-right: -3px;
+  vertical-align: middle;
 }
 
 main {
@@ -132,9 +133,9 @@ md-card md-card-header {
 }
 
 md-card md-card-content {
-  padding: 14px;
+  padding: 10px 12px;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.4em;
 }
 
 .summary > md-card-content {
@@ -275,7 +276,7 @@ md-tooltip {
 @media (min-width: 600px) {
   .pokemon-card-mini {
     width: 166px;
-    height: 214px;
+    height: 220px;
   }
 
   .summary {
@@ -455,6 +456,8 @@ span[class^='gender-'] {
 .pokemon-card-content {
   position: relative;
   padding-top: .6em;
+  box-sizing: border-box;
+  height: 175px;
 }
 
 .pokemon-card-content:after {


### PR DESCRIPTION
Some things have been rearranged to make room – form names are now always on their own line, and the visibility icon is now at the bottom. Here's the new layout:

![New layout with gender symbols](http://i.imgur.com/CMNJSWR.png)

 No more weird behavior with "sometimes two lines" things like this (original layout):

![Old layout](http://i.imgur.com/J4m45TG.png)