### PR TITLE
chore(package): update eslint to version 3.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "chai": "^3.5.0",
     "concurrently": "^3.1.0",
     "dirty-chai": "^1.2.2",
-    "eslint": "^3.7.1",
+    "eslint": "^3.9.1",
     "karma": "^1.2.0",
     "karma-browserify": "^5.0.1",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
This one appears to have gotten lost, which is odd.