### PR TITLE
Initial gen 7 changes

### DIFF
--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -107,7 +107,7 @@ const attributes = {
   regionId: {},
   consoleRegion: {type: 'string'},
   language: {type: 'string'},
-  _rawPk6: {type: 'string'},
+  _rawFile: {type: 'string'},
   _cloneHash: {type: 'string', required: false},
   owner: {model: 'user', type: 'string'},
   box: {model: 'box'},
@@ -118,6 +118,7 @@ const attributes = {
   downloadCount: {defaultsTo: 0},
   publicNotes: {type: 'string', defaultsTo: '', maxLength: Constants.MAX_POKEMON_NOTE_LENGTH},
   privateNotes: {type: 'string', defaultsTo: '', maxLength: Constants.MAX_POKEMON_NOTE_LENGTH},
+  gen: {enum: Constants.GENERATIONS},
   tsv () {
     return (this.tid ^ this.sid) >>> 4;
   },

--- a/api/services/Constants.js
+++ b/api/services/Constants.js
@@ -2,6 +2,7 @@ exports.BOX_VISIBILITIES = ['listed', 'unlisted'];
 exports.DEFAULT_BOX_VISIBILITY_SETTING = 'listed';
 exports.POKEMON_VISIBILITIES = ['private', 'public', 'viewable'];
 exports.DEFAULT_POKEMON_VISIBILITY_SETTING = 'viewable';
+exports.GENERATIONS = [6, 7];
 
 exports.MAX_BOX_SIZE = 3000;
 

--- a/api/services/PokemonHandler.js
+++ b/api/services/PokemonHandler.js
@@ -134,9 +134,9 @@ exports.getSafeBoxSliceForUser = async ({box, user, afterId, beforeId, sliceSize
     : slicedSafeFilteredResults.concat(nextItems);
 };
 
-exports.createPokemonFromPk6 = async ({user, visibility, boxId, file}) => {
+exports.createPokemonFromPk = async ({user, visibility, boxId, file, gen}) => {
   const parseFunc = Buffer.isBuffer(file) ? pk6parse.parseBuffer : pk6parse.parseFile;
-  const parsed = _.attempt(parseFunc, file, {parseNames: true});
+  const parsed = _.attempt(parseFunc, file, {parseNames: true, gen});
   if (_.isError(parsed)) {
     throw {statusCode: 400, message: 'Failed to parse the provided file'};
   }

--- a/client/add/pokemon.ctrl.js
+++ b/client/add/pokemon.ctrl.js
@@ -51,7 +51,7 @@ module.exports = class PokemonAdd {
   }
 
   fileIsValid(file) {
-    return file.name.endsWith('.pk6') || file.name.endsWith('.pkx') || !file.name.includes('.');
+    return file.name.endsWith('.pk6') || file.name.endsWith('.pk7') || file.name.endsWith('.pkx') || !file.name.includes('.');
   }
 
   cancel () {

--- a/client/add/pokemon.view.html
+++ b/client/add/pokemon.view.html
@@ -18,14 +18,14 @@
               ngf-multiple="true" ngf-allow-dir="true" ngf-capture="'other'"
               ngf-change="pkmDialog.addFiles(pkmDialog.draggedFiles)"
               ngf-validate-fn="pkmDialog.fileIsValid($file)"
-              ngf-pattern="'.pk6,.pkx,main'">Drop file/directory here</div>
+              ngf-pattern="'.pk6,.pk7,.pkx,main'">Drop file/directory here</div>
           <span flex></span>
         </div>
 
         <div layout="row">
           <span flex></span>
           <div flex="50">
-            Or select a .pk6/decrypted save file:
+            Or select a .pk6, .pk7 or decrypted save file:
             <input type="file" ngf-select ng-model="pkmDialog.manualFiles" name="file"
                 ngf-max-size="2MB" ng-change="pkmDialog.addFiles(pkmDialog.manualFiles)" multiple
                 ngf-validate-fn="pkmDialog.fileIsValid($file)">

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "passport": "^0.3.2",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
-    "pk6parse": "^0.10.18",
+    "pk6parse": "^1.0.0",
     "sails": "0.12.11",
     "sails-hook-winston": "^1.0.0",
     "sails-mongo": "^0.12.0",

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -176,7 +176,7 @@ describe('BoxController', function () {
     });
     it('does not allow internal properties of Pokémon to be accessed by the query', async () => {
       const res = await agent.get(`/api/v1/box/${boxId}`)
-        .query({pokemonFields: 'speciesName,_rawPk6'});
+        .query({pokemonFields: 'speciesName,_rawFile'});
       expect(res.statusCode).to.equal(200);
       expect(res.body.id).to.equal(boxId);
       expect(res.body.contents).to.eql([

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -494,7 +494,7 @@ describe('PokemonController', () => {
     it('does not leak internal properties of a a pokemon to the client', async () => {
       const pkmn = (await agent.get(`/api/v1/pokemon/${publicId}`)).body;
       expect(pkmn._markedForDeletion).to.not.exist();
-      expect(pkmn._rawPk6).to.not.exist();
+      expect(pkmn._rawFile).to.not.exist();
     });
     it('allows a list of fields to be specified as a query parameter', async () => {
       const res = await agent.get(`/api/v1/pokemon/${viewableId}`).query({
@@ -517,7 +517,7 @@ describe('PokemonController', () => {
     });
     it('does not leak internal properties of a pokemon if specified in the query', async () => {
       const res = await agent.get(`/api/v1/pokemon/${viewableId}`)
-        .query({pokemonFields: '_rawPk6'});
+        .query({pokemonFields: '_rawFile'});
       expect(res.statusCode).to.equal(200);
       expect(res.body).to.eql({});
     });
@@ -769,7 +769,7 @@ describe('PokemonController', () => {
     });
   });
   describe('downloading a pokemon', () => {
-    let publicPkmn, viewablePkmn, privatePkmn, rawPk6;
+    let publicPkmn, viewablePkmn, privatePkmn, rawFile;
     before(async () => {
       const res = await agent.post('/api/v1/pokemon')
         .attach('pk6', `${__dirname}/pk6/pkmn1.pk6`)
@@ -788,7 +788,7 @@ describe('PokemonController', () => {
         .field('box', generalPurposeBox);
       expect(res3.statusCode).to.equal(201);
       privatePkmn = res3.body;
-      rawPk6 = require('fs').readFileSync(`${__dirname}/pk6/pkmn1.pk6`).toString('utf8');
+      rawFile = require('fs').readFileSync(`${__dirname}/pk6/pkmn1.pk6`).toString('utf8');
     });
     it('allows a user to download their own pokemon, regardless of visibility', async () => {
       const res = await agent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer()
@@ -797,46 +797,46 @@ describe('PokemonController', () => {
           `attachment; filename="${publicPkmn.nickname}-${publicPkmn.id}.pk6"`
         );
       expect(res.statusCode).to.equal(200);
-      expect(res.text).to.equal(rawPk6);
+      expect(res.text).to.equal(rawFile);
       const res2 = await agent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(200);
-      expect(res2.text).to.equal(rawPk6);
+      expect(res2.text).to.equal(rawFile);
       const res3 = await agent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(200);
-      expect(res3.text).to.equal(rawPk6);
+      expect(res3.text).to.equal(rawFile);
     });
     it("only allows other users to download someone's public pokemon", async () => {
       const res = await otherAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       expect(res.statusCode).to.equal(200);
-      expect(res.text).to.equal(rawPk6);
+      expect(res.text).to.equal(rawFile);
       const res2 = await otherAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(403);
-      expect(res2.text).to.not.equal(rawPk6);
+      expect(res2.text).to.not.equal(rawFile);
       const res3 = await otherAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(403);
-      expect(res3.text).to.not.equal(rawPk6);
+      expect(res3.text).to.not.equal(rawFile);
     });
     it('only allows an unauthenticated user to download a public pokemon', async () => {
       const res = await noAuthAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       expect(res.statusCode).to.equal(200);
-      expect(res.text).to.equal(rawPk6);
+      expect(res.text).to.equal(rawFile);
       const res2 = await noAuthAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(403);
-      expect(res2.text).to.not.equal(rawPk6);
+      expect(res2.text).to.not.equal(rawFile);
       const res3 = await noAuthAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(403);
-      expect(res3.text).to.not.equal(rawPk6);
+      expect(res3.text).to.not.equal(rawFile);
     });
     it('allows an admin to download any pokemon, regardless of visibility', async () => {
       const res = await adminAgent.get(`/api/v1/pokemon/${publicPkmn.id}/pk6`).buffer();
       expect(res.statusCode).to.equal(200);
-      expect(res.text).to.equal(rawPk6);
+      expect(res.text).to.equal(rawFile);
       const res2 = await adminAgent.get(`/api/v1/pokemon/${viewablePkmn.id}/pk6`).buffer();
       expect(res2.statusCode).to.equal(200);
-      expect(res2.text).to.equal(rawPk6);
+      expect(res2.text).to.equal(rawFile);
       const res3 = await adminAgent.get(`/api/v1/pokemon/${privatePkmn.id}/pk6`).buffer();
       expect(res3.statusCode).to.equal(200);
-      expect(res3.text).to.equal(rawPk6);
+      expect(res3.text).to.equal(rawFile);
     });
     it('increases the download count with downloads by third parties', async () => {
       const initialCount = (await agent.get(`/api/v1/pokemon/${publicPkmn.id}`)).body.downloadCount;


### PR DESCRIPTION
Not ready yet, but I thought I'd get this up just now.

Fixes #541

I have updated so that it uses the pk6parse gen 7 changes.

TODO:

- [ ] Remove the extra single-upload gen 7 call I made, because that won't work
- [ ] Either add a multi-upload for gen 7, or figure out a way to use them both on the same call
- [ ] Call the gen 7 calls when uploading .pk7s
- [ ] Wait for the pk6parse release