### PR TITLE
Add API support for gen 7

### DIFF
--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -179,7 +179,7 @@ module.exports = _.mapValues({
       return res.forbidden();
     }
     res.attachment(`${pokemon.nickname}-${pokemon.id}.pk6`);
-    res.status(200).send(Buffer.from(pokemon._rawPk6, 'base64'));
+    res.status(200).send(Buffer.from(pokemon._rawFile || pokemon._rawPk6, 'base64'));
     if (!userIsOwner && pokemon.visibility === 'public') {
       await pokemon.incrementDownloadCount();
     }

--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -52,7 +52,7 @@ module.exports = _.mapValues({
   *   ...
   * ]
   */
-  async uploadMultiPk6 (req, res) {
+  async uploadMultipleFiles (req, res) {
     const files = req.param('files');
     if (!Array.isArray(files)) {
       return res.status(400).json('Invalid files array');
@@ -77,11 +77,13 @@ module.exports = _.mapValues({
       if (_.isError(fileBuf)) {
         throw {statusCode: 400, message: 'Failed to parse the provided file'};
       }
+
       return PokemonHandler.createPokemonFromPk6({
         user: req.user,
         visibility: file.visibility || defaultVisibility,
         boxId: file.box,
-        file: fileBuf
+        file: fileBuf,
+        gen: file.gen
       });
     }));
 

--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -17,7 +17,7 @@ module.exports = _.mapValues({
     if (!files.length) {
       return res.status(400).json('No files uploaded');
     }
-    return PokemonHandler.createPokemonFromPk6({
+    return PokemonHandler.createPokemonFromFile({
       user: req.user,
       visibility,
       boxId: params.box,
@@ -78,7 +78,7 @@ module.exports = _.mapValues({
         throw {statusCode: 400, message: 'Failed to parse the provided file'};
       }
 
-      return PokemonHandler.createPokemonFromPk6({
+      return PokemonHandler.createPokemonFromFile({
         user: req.user,
         visibility: file.visibility || defaultVisibility,
         boxId: file.box,

--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -107,7 +107,11 @@ const attributes = {
   regionId: {},
   consoleRegion: {type: 'string'},
   language: {type: 'string'},
-  _rawPk6: {type: 'string'},
+
+  // TODO: Remove references to _rawPk6 (only used here to avoid needing a migration)
+  _rawFile: {type: 'string', required: false},
+  _rawPk6: {type: 'string', required: false},
+
   _cloneHash: {type: 'string', required: false},
   owner: {model: 'user', type: 'string'},
   box: {model: 'box'},

--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -110,6 +110,7 @@ const attributes = {
   language: {type: 'string'},
 
   // TODO: Remove references to _rawPk6 (only used here to avoid needing a migration)
+  // https://github.com/porygonco/pk6parse/issues/12
   _rawFile: {type: 'string', required: false},
   _rawPk6: {type: 'string', required: false},
 

--- a/api/models/Pokemon.js
+++ b/api/models/Pokemon.js
@@ -69,6 +69,7 @@ const attributes = {
   notOt: {type: 'string', required: false},
   notOtGender: {type: 'string'},
   currentHandlerIsOt: {type: 'boolean'},
+  gen: {required: false},
   geoLocation1RegionId: {},
   geoLocation1CountryId: {},
   geoLocation2RegionId: {},

--- a/api/services/PokemonHandler.js
+++ b/api/services/PokemonHandler.js
@@ -134,7 +134,7 @@ exports.getSafeBoxSliceForUser = async ({box, user, afterId, beforeId, sliceSize
     : slicedSafeFilteredResults.concat(nextItems);
 };
 
-exports.createPokemonFromPk6 = async ({user, visibility, boxId, file, gen = 6}) => {
+exports.createPokemonFromFile = async ({user, visibility, boxId, file, gen = 6}) => {
   const parseFunc = Buffer.isBuffer(file) ? pk6parse.parseBuffer : pk6parse.parseFile;
   const SUPPORTED_GENS = pk6parse.SUPPORTED_GENS || [6];
 

--- a/api/services/PokemonHandler.js
+++ b/api/services/PokemonHandler.js
@@ -152,6 +152,11 @@ exports.createPokemonFromPk6 = async ({user, visibility, boxId, file}) => {
   parsed._boxVisibility = box.visibility;
   parsed.owner = user.name;
   parsed.visibility = visibility;
+
+  // The next two lines will be a no-op after pk6parse outputs _rawFile instead of _rawPk6.
+  parsed._rawFile = parsed._rawFile || parsed._rawPk6;
+  delete parsed._rawPk6;
+
   return parsed;
 };
 

--- a/api/services/PokemonHandler.js
+++ b/api/services/PokemonHandler.js
@@ -134,9 +134,15 @@ exports.getSafeBoxSliceForUser = async ({box, user, afterId, beforeId, sliceSize
     : slicedSafeFilteredResults.concat(nextItems);
 };
 
-exports.createPokemonFromPk6 = async ({user, visibility, boxId, file}) => {
+exports.createPokemonFromPk6 = async ({user, visibility, boxId, file, gen = 6}) => {
   const parseFunc = Buffer.isBuffer(file) ? pk6parse.parseBuffer : pk6parse.parseFile;
-  const parsed = _.attempt(parseFunc, file, {parseNames: true});
+  const SUPPORTED_GENS = pk6parse.SUPPORTED_GENS || [6];
+
+  if (!SUPPORTED_GENS.includes(gen)) {
+    throw {statusCode: 400, message: 'Unsupported generation'};
+  }
+
+  const parsed = _.attempt(parseFunc, file, {parseNames: true, gen});
   if (_.isError(parsed)) {
     throw {statusCode: 400, message: 'Failed to parse the provided file'};
   }
@@ -152,8 +158,10 @@ exports.createPokemonFromPk6 = async ({user, visibility, boxId, file}) => {
   parsed._boxVisibility = box.visibility;
   parsed.owner = user.name;
   parsed.visibility = visibility;
+  parsed.gen = parsed.gen === undefined ? gen : parsed.gen;
 
-  // The next two lines will be a no-op after pk6parse outputs _rawFile instead of _rawPk6.
+  // The next three lines will be a no-op after pk6parse outputs `gen`, and `_rawFile` instead of `_rawPk6`.
+  parsed.gen = typeof parsed.gen === 'undefined' ? gen : parsed.gen;
   parsed._rawFile = parsed._rawFile || parsed._rawPk6;
   delete parsed._rawPk6;
 

--- a/api/services/PokemonHandler.js
+++ b/api/services/PokemonHandler.js
@@ -158,10 +158,9 @@ exports.createPokemonFromFile = async ({user, visibility, boxId, file, gen = 6})
   parsed._boxVisibility = box.visibility;
   parsed.owner = user.name;
   parsed.visibility = visibility;
-  parsed.gen = parsed.gen === undefined ? gen : parsed.gen;
 
   // The next three lines will be a no-op after pk6parse outputs `gen`, and `_rawFile` instead of `_rawPk6`.
-  parsed.gen = typeof parsed.gen === 'undefined' ? gen : parsed.gen;
+  parsed.gen = parsed.gen || gen;
   parsed._rawFile = parsed._rawFile || parsed._rawPk6;
   delete parsed._rawPk6;
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -38,7 +38,7 @@ module.exports.policies = {
 
   PokemonController: {
     uploadpk6: user,
-    uploadMultiPk6: user,
+    uploadMultipleFiles: user,
     get: anyone,
     delete: user,
     undelete: user,

--- a/config/routes.js
+++ b/config/routes.js
@@ -53,7 +53,7 @@ module.exports.routes = {
   // Pokemon
 
   'post /api/v1/pokemon': 'PokemonController.uploadpk6',
-  'post /api/v1/pokemon/multi': 'PokemonController.uploadMultiPk6',
+  'post /api/v1/pokemon/multi': 'PokemonController.uploadMultipleFiles',
 
   'get /api/v1/pokemon/:id': 'PokemonController.get',
   'get /api/v1/pokemon/:id/pk6': 'PokemonController.download',

--- a/test/controller/box.js
+++ b/test/controller/box.js
@@ -176,7 +176,7 @@ describe('BoxController', function () {
     });
     it('does not allow internal properties of Pokémon to be accessed by the query', async () => {
       const res = await agent.get(`/api/v1/box/${boxId}`)
-        .query({pokemonFields: 'speciesName,_rawPk6'});
+        .query({pokemonFields: 'speciesName,_rawPk6,_rawFile'});
       expect(res.statusCode).to.equal(200);
       expect(res.body.id).to.equal(boxId);
       expect(res.body.contents).to.eql([

--- a/test/controller/pokemon.js
+++ b/test/controller/pokemon.js
@@ -495,6 +495,7 @@ describe('PokemonController', () => {
       const pkmn = (await agent.get(`/api/v1/pokemon/${publicId}`)).body;
       expect(pkmn._markedForDeletion).to.not.exist();
       expect(pkmn._rawPk6).to.not.exist();
+      expect(pkmn._rawFile).to.not.exist();
     });
     it('allows a list of fields to be specified as a query parameter', async () => {
       const res = await agent.get(`/api/v1/pokemon/${viewableId}`).query({
@@ -517,7 +518,7 @@ describe('PokemonController', () => {
     });
     it('does not leak internal properties of a pokemon if specified in the query', async () => {
       const res = await agent.get(`/api/v1/pokemon/${viewableId}`)
-        .query({pokemonFields: '_rawPk6'});
+        .query({pokemonFields: '_rawPk6,_rawFile'});
       expect(res.statusCode).to.equal(200);
       expect(res.body).to.eql({});
     });


### PR DESCRIPTION
This allows a `gen` property to be specified from the multi-upload API, defaulting to 6. The property is passed as an option to pk6parse (which currently doesn't do anything with it), and it's sent as a regular property to the client.

Uploads are only allowed to have a gen that is in the `pk6parse.SUPPORTED_GENS` array, or `[6]` is `pk6parse.SUPPORTED_GENS` doesn't exist (which is the case for the old version of pk6parse). This means that gen 7 uploads are currently not allowed (since someone could upload a file with `gen: 7` that fails future validation checks). To enable them, we should export `SUPPORTED_GENS = [6, 7]` from pk6parse when the parser is ready, which will make the server accept gen 7 uploads.